### PR TITLE
force event transmission from the rotary encoder to bpod

### DIFF
--- a/iblrig/rotary_encoder.py
+++ b/iblrig/rotary_encoder.py
@@ -40,4 +40,5 @@ class MyRotaryEncoder(object):
         m.set_zero_position()  # Not necessarily needed
         m.set_thresholds(self.SET_THRESHOLDS)
         m.enable_thresholds(self.ENABLE_THRESHOLDS)
+        m.enable_evt_transmission()
         m.close()


### PR DESCRIPTION
Just ensure that the rotary encoder is properly configured, even if other
programs left it in a bad state (disabled events transmission in this case).