### PR TITLE
added write timeout

### DIFF
--- a/iblrig/frame2TTL.py
+++ b/iblrig/frame2TTL.py
@@ -25,7 +25,7 @@ class Frame2TTL(object):
 
     def connect(self, serial_port) -> serial.Serial:
         """Create connection to serial_port"""
-        ser = serial.Serial(port=serial_port, baudrate=115200, timeout=1)
+        ser = serial.Serial(port=serial_port, baudrate=115200, timeout=1., write_timeout=1.)
         self.connected = True
         return ser
 


### PR DESCRIPTION
Writing to the frame2ttl sometimes hangs, but the lack of a timeout meant that the code would not throw a useful error to the user. Added in a write time-out of 1s.