### PR TITLE
TTL on trial end

### DIFF
--- a/iblrig/base_choice_world.py
+++ b/iblrig/base_choice_world.py
@@ -544,7 +544,7 @@ class HabituationChoiceWorldSession(ChoiceWorldSession):
             state_name="iti",
             state_timer=self.task_params.ITI_DELAY_SECS,
             state_change_conditions={"Tup": "exit"},
-            output_actions=[],
+            output_actions=[("BNC1", 255)]
         )
         return sma
 


### PR DESCRIPTION
Added a TTL at trial end to allow us to align trial events on recording rigs.  With the trial interval TTLs identical to ephysChoiceWorld we shouldn't need to write any new code for habituationChoiceWorld clock alignment.