### PR TITLE
Fix for error when calling transfer_data without a local path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 -------------------------------
 
+8.10.2
+------
+* hot-fix parsing of path args in transfer_data
+
 8.10.1
 ------
 * more reliable way to check for dirty repository

--- a/iblrig/__init__.py
+++ b/iblrig/__init__.py
@@ -4,7 +4,7 @@
 # 3) Check CI and eventually wet lab test
 # 4) Pull request to iblrigv8
 # 5) git tag the release in accordance to the version number below (after merge!)
-__version__ = '8.10.1'
+__version__ = '8.10.2'
 
 # The following method call will try to get post-release information (i.e. the number of commits since the last tagged
 # release corresponding to the one above), plus information about the state of the local repository (dirty/broken)

--- a/iblrig/commands.py
+++ b/iblrig/commands.py
@@ -35,12 +35,17 @@ def transfer_data(local_path=None, remote_path=None, dry=False):
     """
     Copies the behavior data from the rig to the local server if the session has more than 42 trials
     If the hardware settings file contains MAIN_SYNC=True, the number of expected devices is set to 1
-    :param local_path: local path to the subjects folder
-    :param weeks:
+    :param local_path: local path to the subjects folder, otherwise uses the local_data_folder key in
+    the iblrig_settings.yaml file, or the iblrig_data directory in the home path.
     :param dry:
     :return:
     """
+    # If paths not passed, uses those defined in the iblrig_settings.yaml file
     rig_paths = get_local_and_remote_paths(local_path=local_path, remote_path=remote_path)
+    local_path = rig_paths.local_subjects_folder
+    remote_path = rig_paths.remote_subjects_folder
+    assert isinstance(local_path, Path)  # get_local_and_remote_paths should always return Path obj
+
     hardware_settings = load_settings_yaml('hardware_settings.yaml')
     number_of_expected_devices = 1 if hardware_settings.get('MAIN_SYNC', True) else None
 


### PR DESCRIPTION
See issue #514.  I was unable to run tests locally ~~as it requires the branch to already exist.  @bimac perhaps there's an option to suppress such things in development?~~ [Edit] This issue was actually `ModuleNotFoundError: No module named 'pybpodapi'`