### PR TITLE
Show dialogs with append

### DIFF
--- a/iblrig/base_tasks.py
+++ b/iblrig/base_tasks.py
@@ -90,7 +90,7 @@ class BaseSession(ABC):
         self._setup_loggers(level=log_level)
         if not isinstance(self, EmptySession):
             log.info(f'Running iblrig {iblrig.__version__}, pybpod version {pybpodapi.__version__}')
-        self.interactive = False if append else interactive
+        self.interactive = interactive
         self._one = one
         self.init_datetime = datetime.datetime.now()
 
@@ -401,14 +401,16 @@ class BaseSession(ABC):
 
     def run(self):
         """
-        Common pre-run instructions for all tasks: singint handler for a graceful exit
+        Common pre-run instructions for all tasks: sigint handler for a graceful exit
         :return:
         """
         # here we make sure we connect to the hardware before writing the session to disk
         # this prevents from incrementing endlessly the session number if the hardware fails to connect
         self.start_hardware()
         self.create_session()
-        if self.session_info.SUBJECT_WEIGHT is None and self.interactive:
+        # When not running the first chained protocol, we can skip the weighing dialog
+        first_protocol = int(self.paths.SESSION_RAW_DATA_FOLDER.name.split('_')[-1]) == 0
+        if self.session_info.SUBJECT_WEIGHT is None and self.interactive and first_protocol:
             self.session_info.SUBJECT_WEIGHT = graph.numinput(
                 'Subject weighing (gr)', f'{self.session_info.SUBJECT_NAME} weight (gr):', nullable=False
             )
@@ -439,8 +441,8 @@ class BaseSession(ABC):
     @abc.abstractmethod
     def start_hardware(self):
         """
-        This methods doesn't explicitly start the mixins as the order has to be defined in the child classes
-        This needs to be implemented in the child classes, and should start and connect to all hardware pieces
+        This method doesn't explicitly start the mixins as the order has to be defined in the child classes.
+        This needs to be implemented in the child classes, and should start and connect to all hardware pieces.
         """
         pass
 

--- a/iblrig/test/test_base_tasks.py
+++ b/iblrig/test/test_base_tasks.py
@@ -74,7 +74,7 @@ class TestHardwareMixins(unittest.TestCase):
 
     @mock.patch('iblrig.base_tasks.call_bonsai')
     def test_bonsai_recording_mixin(self, mock_call_bonsai):
-        # create an session with the bonsai recording mixin only and all tests parameters
+        # create a session with the bonsai recording mixin only and all tests parameters
         session = mixin_factory(BonsaiRecordingMixin)
         session.init_mixin_bonsai_recordings()
         # this will fail if the udp clients are not alive, which they should be
@@ -89,7 +89,7 @@ class TestHardwareMixins(unittest.TestCase):
         session.stop_mixin_bonsai_recordings()
 
     @mock.patch('iblrig.base_tasks.call_bonsai')
-    def test_bonsai_visual_stimulus_mixin(self, mock_call_bonsai):
+    def test_bonsai_visual_stimulus_mixin(self, _):
         session = mixin_factory(BonsaiVisualStimulusMixin)
         session.start_mixin_bonsai_visual_stimulus()
         session.init_mixin_bonsai_visual_stimulus()
@@ -219,22 +219,22 @@ class TestPathCreation(unittest.TestCase):
             task_parameter_file=ChoiceWorldSession.base_parameters_file,
         )
         first_task.create_session()
-        # append a new protocol the the current task
+        # append a new protocol to the current task
         second_task = EmptyHardwareSession(append=True, iblrig_settings={'iblrig_remote_data_path': False}, **task_kwargs)
         # unless the task has reached the create session stage, there is only one protocol in there
         self.assertEqual(
-            set([d.name for d in first_task.paths.SESSION_FOLDER.iterdir() if d.is_dir()]), set(['raw_task_data_00'])
+            set(d.name for d in first_task.paths.SESSION_FOLDER.iterdir() if d.is_dir()), {'raw_task_data_00'}
         )
         # this will create and add to the acquisition description file
         second_task.create_session()
         self.assertEqual(
-            set([d.name for d in first_task.paths.SESSION_FOLDER.iterdir() if d.is_dir()]),
-            set(['raw_task_data_00', 'raw_task_data_01']),
+            set(d.name for d in first_task.paths.SESSION_FOLDER.iterdir() if d.is_dir()),
+            {'raw_task_data_00', 'raw_task_data_01'},
         )
         description = read_params(second_task.paths['SESSION_FOLDER'])
         # we should also find the protocols in the acquisition description file
-        protocols = set([p[EmptyHardwareSession.protocol_name]['collection'] for p in description['tasks']])
-        self.assertEqual(protocols, set(['raw_task_data_00', 'raw_task_data_01']))
+        protocols = set(p[EmptyHardwareSession.protocol_name]['collection'] for p in description['tasks'])
+        self.assertEqual(protocols, {'raw_task_data_00', 'raw_task_data_01'})
 
     def test_create_session_with_remote(self):
         with tempfile.TemporaryDirectory() as td:
@@ -292,3 +292,40 @@ class TestTaskArguments(unittest.TestCase):
         self.assertTrue(kwargs['interactive'])
         self.assertEqual(kwargs['subject'], 'toto')
         self.assertEqual(kwargs['training_phase'], 4)
+
+
+class TestRun(unittest.TestCase):
+    """Test BaseSession.run method and append kwarg."""
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(tmp.name)
+        self.addCleanup(tmp.cleanup)
+        self.iblrig_settings = {'iblrig_remote_data_path': False, 'iblrig_local_data_path': self.tmp}
+
+        self.task_kwargs = copy.deepcopy(TASK_KWARGS)
+        self.task_kwargs['hardware_settings']['MAIN_SYNC'] = False
+        self.task_kwargs['interactive'] = True
+        self.task_kwargs['iblrig_settings'] = self.iblrig_settings
+        self.task_kwargs['task_parameter_file'] = ChoiceWorldSession.base_parameters_file
+
+    @mock.patch('iblrig.base_tasks.graph.numinput', side_effect=(23.5, 20, 35))
+    def test_dialogs(self, input_mock):
+        """Test that weighing dialog used only on first of chained protocols."""
+        first_task = EmptyHardwareSession(**self.task_kwargs)
+        # Logging to file causes tempdir cleanup issues so we simply don't call setup_loggers
+        with mock.patch.object(first_task, '_setup_loggers'):
+            # Check that weighing GUI created
+            first_task.run()
+        input_mock.assert_called()
+        self.assertEqual(23.5, first_task.session_info['SUBJECT_WEIGHT'])
+        self.assertEqual(20, first_task.session_info['POOP_COUNT'])
+
+        # Append a new protocol to the current task. Weighting GUI should not be instantiated
+        input_mock.reset_mock()
+        second_task = EmptyHardwareSession(append=True, **self.task_kwargs)
+        with mock.patch.object(second_task, '_setup_loggers'):
+            second_task.run()
+        input_mock.assert_called_once()
+        self.assertIsNone(second_task.session_info['SUBJECT_WEIGHT'])
+        self.assertEqual(35, second_task.session_info['POOP_COUNT'])


### PR DESCRIPTION
When append is true, the weighing dialog is only shown on the first protocol.  All other dialogs are shown, although I noticed that the wizard arg only controls whether the poop count dialog is shown - it doesn't affect the weighing dialog. I left that behaviour alone although it is confusing and the difference between interactive and wizard should be clarified in the documentation.  The effect of the append arg on the weighing dialog is covered by tests. I have _not_ tested whether the online plots appear when append is true, however interactive is no longer affected by the state of append.