### PR TITLE
Resolves #622

### DIFF
--- a/iblrig/base_tasks.py
+++ b/iblrig/base_tasks.py
@@ -53,6 +53,7 @@ class BaseSession(ABC):
     base_parameters_file: Path | None = None
     is_mock = False
     extractor_tasks = None
+    """list of str: One or more ibllib.pipes.tasks.Task names for task extraction."""
     logger: logging.Logger = None
     """logging.Logger: Log instance used solely to keep track of log level passed to constructor."""
 
@@ -99,6 +100,7 @@ class BaseSession(ABC):
         self.interactive = interactive
         self._one = one
         self.init_datetime = datetime.datetime.now()
+        self.extractor_tasks = None
 
         # loads in the settings: first load the files, then update with the input argument if provided
         self.hardware_settings = load_pydantic_yaml(HardwareSettings, file_hardware_settings)

--- a/iblrig_tasks/_iblrig_tasks_ImagingChoiceWorld/task.py
+++ b/iblrig_tasks/_iblrig_tasks_ImagingChoiceWorld/task.py
@@ -4,9 +4,9 @@ from iblrig.base_choice_world import BiasedChoiceWorldSession
 
 class Session(BiasedChoiceWorldSession):
     protocol_name = '_iblrig_tasks_imagingChoiceWorld'
-    extractor_tasks = ['TrialRegisterRaw', 'ChoiceWorldTrials']
 
-    def draw_quiescent_period(self):
+    @staticmethod
+    def draw_quiescent_period():
         """
         For this task we double the quiescence period texp draw and remove the absolute
         offset of 200ms. The resulting is a truncated exp distribution between 400ms and 1 sec

--- a/iblrig_tasks/_iblrig_tasks_advancedChoiceWorld/task.py
+++ b/iblrig_tasks/_iblrig_tasks_advancedChoiceWorld/task.py
@@ -14,12 +14,11 @@ class Session(ActiveChoiceWorldSession):
     """
     Advanced Choice World is the ChoiceWorld task using fixed 50/50 probability for the side
     and contrasts defined in the parameters.
-    It differs from TraininChoiceWorld in that it does not implement adaptive contrasts or debiasing,
+    It differs from TrainingChoiceWorld in that it does not implement adaptive contrasts or debiasing,
     and it differs from BiasedChoiceWorld in that it does not implement biased blocks.
     """
 
     protocol_name = '_iblrig_tasks_advancedChoiceWorld'
-    extractor_tasks = ['TrialRegisterRaw', 'ChoiceWorldTrials', 'TrainingStatus']
 
     def __init__(
         self,

--- a/iblrig_tasks/_iblrig_tasks_biasedChoiceWorld/task.py
+++ b/iblrig_tasks/_iblrig_tasks_biasedChoiceWorld/task.py
@@ -3,7 +3,7 @@ from iblrig.base_choice_world import BiasedChoiceWorldSession
 
 
 class Session(BiasedChoiceWorldSession):
-    extractor_tasks = ['TrialRegisterRaw', 'ChoiceWorldTrials', 'TrainingStatus']
+    ...
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/iblrig_tasks/_iblrig_tasks_ephysChoiceWorld/task.py
+++ b/iblrig_tasks/_iblrig_tasks_ephysChoiceWorld/task.py
@@ -12,7 +12,6 @@ from iblrig.base_choice_world import BiasedChoiceWorldSession
 
 class Session(BiasedChoiceWorldSession):
     protocol_name = '_iblrig_tasks_ephysChoiceWorld'
-    extractor_tasks = ['TrialRegisterRaw', 'ChoiceWorldTrials', 'TrainingStatus']
 
     def __init__(self, *args, session_template_id=0, **kwargs):
         super().__init__(*args, **kwargs)

--- a/iblrig_tasks/_iblrig_tasks_habituationChoiceWorld/task.py
+++ b/iblrig_tasks/_iblrig_tasks_habituationChoiceWorld/task.py
@@ -3,7 +3,7 @@ from iblrig.base_choice_world import HabituationChoiceWorldSession
 
 
 class Session(HabituationChoiceWorldSession):
-    extractor_tasks = ['TrialRegisterRaw', 'HabituationTrials']
+    ...
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/iblrig_tasks/_iblrig_tasks_neuroModulatorChoiceWorld/task.py
+++ b/iblrig_tasks/_iblrig_tasks_neuroModulatorChoiceWorld/task.py
@@ -13,7 +13,6 @@ log = logging.getLogger(__name__)
 
 class Session(BiasedChoiceWorldSession):
     protocol_name = '_iblrig_tasks_neuromodulatorChoiceWorld'
-    extractor_tasks = ['TrialRegisterRaw', 'ChoiceWorldNeuromodulators', 'TrainingStatus']
 
     def __init__(self, *args, **kwargs):
         super(Session, self).__init__(*args, **kwargs)

--- a/iblrig_tasks/_iblrig_tasks_passiveChoiceWorld/task.py
+++ b/iblrig_tasks/_iblrig_tasks_passiveChoiceWorld/task.py
@@ -13,10 +13,10 @@ log = logging.getLogger('iblrig.task')
 
 class Session(ChoiceWorldSession):
     protocol_name = '_iblrig_tasks_passiveChoiceWorld'
-    extractor_tasks = ['PassiveRegisterRaw', 'PassiveTask']
 
     def __init__(self, *args, session_template_id=0, **kwargs):
         super(ChoiceWorldSession, self).__init__(**kwargs)
+        self.extractor_tasks = ['PassiveRegisterRaw', 'PassiveTask']
         self.task_params.SESSION_TEMPLATE_ID = session_template_id
         all_trials = pd.read_parquet(Path(__file__).parent.joinpath('passiveChoiceWorld_trials_fixtures.pqt'))
         self.trials_table = all_trials[all_trials['session_id'] == self.task_params.SESSION_TEMPLATE_ID].copy()

--- a/iblrig_tasks/_iblrig_tasks_trainingChoiceWorld/task.py
+++ b/iblrig_tasks/_iblrig_tasks_trainingChoiceWorld/task.py
@@ -6,7 +6,6 @@ ADAPTIVE_REWARD = -1.0
 
 
 class Session(TrainingChoiceWorldSession):
-    extractor_tasks = ['TrialRegisterRaw', 'ChoiceWorldTrials', 'TrainingStatus']
 
     @staticmethod
     def extra_parser():

--- a/iblrig_tasks/_iblrig_tasks_trainingPhaseChoiceWorld/task.py
+++ b/iblrig_tasks/_iblrig_tasks_trainingPhaseChoiceWorld/task.py
@@ -12,7 +12,6 @@ with open(Path(__file__).parent.joinpath('task_parameters.yaml')) as f:
 
 class Session(TrainingChoiceWorldSession):
     protocol_name = '_iblrig_tasks_trainingPhaseChoiceWorld'
-    extractor_tasks = ['TrialRegisterRaw', 'ChoiceWorldTrials', 'TrainingStatus']
 
     def __init__(self, *args, training_level=DEFAULTS['TRAINING_PHASE'], debias=DEFAULTS['DEBIAS'], **kwargs):
         super(Session, self).__init__(*args, training_phase=training_level, **kwargs)


### PR DESCRIPTION
Extractor tasks are no longer class attributes but rather object attributes.  I have removed the extractor tasks list from most task protocol objects as the defaults are handled by ibllib. Note that the task in question is dynamic depending on the main sync anyway.

The following solution works for Bpod vs 1 other DAQ:
https://github.com/int-brain-lab/project_extraction/blob/6d34f1769fed5c60a4dc4eb5bfd860d6d040e437/iblrig_custom_tasks/samuel_cuedBiasedChoiceWorld/task.py#L25-L27

For more than 1 DAQ type we may need ibllib to infer the task type from the experiment description sync key, or by having `make_pipeline` use some task type map defined in the project_extraction repo.