### PR TITLE
one.alf.files -> one.alf.path

### DIFF
--- a/iblrig/online_plots.py
+++ b/iblrig/online_plots.py
@@ -11,6 +11,7 @@ import seaborn as sns
 from pandas.api.types import CategoricalDtype
 
 import one.alf.io
+import one.alf.path
 from iblrig.choiceworld import get_subject_training_info
 from iblrig.misc import online_std
 from iblrig.raw_data_loaders import load_task_jsonable
@@ -50,7 +51,7 @@ class DataModel:
     time_elapsed = 0.0
 
     def __init__(self, settings_file: Path | None):
-        self.session_path = one.alf.files.get_session_path(settings_file) or ''
+        self.session_path = one.alf.path.get_session_path(settings_file) or ''
         self.last_trials = pd.DataFrame(
             columns=['correct', 'signed_contrast', 'stim_on', 'play_tone', 'reward_time', 'error_time', 'response_time'],
             index=np.arange(NTRIALS_PLOT),

--- a/iblrig/transfer_experiments.py
+++ b/iblrig/transfer_experiments.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import ibllib.pipes.misc
 import iblrig
-import one.alf.files as alfiles
+import one.alf.path as alfiles
 from ibllib.io import raw_data_loaders, session_params
 from ibllib.pipes.misc import sleepless
 from iblrig.raw_data_loaders import load_task_jsonable

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "ci", "dev", "doc", "project-extraction", "test", "typing"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:60948b73e6c0cf6b0e4e0fd3ce6557231ad52be77ce8672a875515b803095306"
+content_hash = "sha256:3a5034cf2aa96d697c83513a939bfe568e77f33147059f5c4d8a0bf58b397f61"
 
 [[metadata.targets]]
 requires_python = "==3.10.*"
@@ -749,8 +749,8 @@ files = [
 
 [[package]]
 name = "ibl-neuropixel"
-version = "1.4.0"
-requires_python = ">=3.8"
+version = "1.5.0"
+requires_python = ">=3.10"
 summary = "Collection of tools for Neuropixel 1.0 and 2.0 probes data"
 groups = ["default"]
 dependencies = [
@@ -764,8 +764,8 @@ dependencies = [
     "scipy>=1.11",
 ]
 files = [
-    {file = "ibl_neuropixel-1.4.0-py3-none-any.whl", hash = "sha256:c5e529662fcf0040078e1746bc90304b80b107b2e91030a3b2d381f3b7b9c84f"},
-    {file = "ibl_neuropixel-1.4.0.tar.gz", hash = "sha256:78f46b3174f8e3ed1307ed805673419ea4973d8497152f774c1f582fe891720c"},
+    {file = "ibl_neuropixel-1.5.0-py3-none-any.whl", hash = "sha256:5e37a62098802c89088ddad846c1a1f1805341e271ac6be46f8f2a39118ae921"},
+    {file = "ibl_neuropixel-1.5.0.tar.gz", hash = "sha256:4c4a5e08dc4a21209a79b0c0044cbab32e0602efe25ec23b2fbf175d2ad44e66"},
 ]
 
 [[package]]
@@ -789,21 +789,21 @@ files = [
 
 [[package]]
 name = "ibllib"
-version = "2.39.1"
+version = "2.40.1"
 requires_python = ">=3.8"
 summary = "IBL libraries"
 groups = ["default"]
 dependencies = [
-    "ONE-api~=2.9.rc0",
+    "ONE-api>=2.10",
     "boto3",
     "click>=7.0.0",
     "colorlog>=4.0.2",
     "flake8>=3.7.8",
     "globus-sdk",
     "graphviz",
-    "ibl-neuropixel>=1.0.1",
+    "ibl-neuropixel>=1.5.0",
     "iblatlas>=0.5.3",
-    "iblutil>=1.11.0",
+    "iblutil>=1.13.0",
     "imagecodecs",
     "matplotlib>=3.0.3",
     "mtscomp>=1.0.1",
@@ -828,8 +828,8 @@ dependencies = [
     "tqdm>=4.32.1",
 ]
 files = [
-    {file = "ibllib-2.39.1-py3-none-any.whl", hash = "sha256:261e7798befb5daed08d70f10918a9739003e38026357875ea2d6dcc912fcc4e"},
-    {file = "ibllib-2.39.1.tar.gz", hash = "sha256:79ede021deb02b98810efc0d70b10913db7c53109c4cfe2c18028d5d214a449b"},
+    {file = "ibllib-2.40.1-py3-none-any.whl", hash = "sha256:1eab186949395f4a660bad1f20a1e32893ea0cf4d83f90a6d7146e6bc3d31a44"},
+    {file = "ibllib-2.40.1.tar.gz", hash = "sha256:8dbb2b70d3bf07b05eeb0b6cc32abd01192fc31fc6fe45832b191e5333eaff58"},
 ]
 
 [[package]]
@@ -871,7 +871,7 @@ files = [
 
 [[package]]
 name = "iblutil"
-version = "1.13.0"
+version = "1.14.0"
 requires_python = ">=3.8"
 summary = "IBL utilities"
 groups = ["default"]
@@ -885,8 +885,8 @@ dependencies = [
     "tqdm>=4.32.1",
 ]
 files = [
-    {file = "iblutil-1.13.0-py3-none-any.whl", hash = "sha256:14a1d3bef30564d633433b3f9dbf8c3ec7c2bb3dfea2d1cd077107f31a986209"},
-    {file = "iblutil-1.13.0.tar.gz", hash = "sha256:cc16a1fcc3e82fe2d6425e2b24fc2952e1d49824bfbf6a7a7d7feb502fdae7f1"},
+    {file = "iblutil-1.14.0-py3-none-any.whl", hash = "sha256:b402e834a0e719c315b989f538e34b99d9c46430c2c2f5e6606f6951063c938e"},
+    {file = "iblutil-1.14.0.tar.gz", hash = "sha256:1b2214d7e1b4b3e47c0d296a2a7181ca98592383648d032eca5d949b538e694c"},
 ]
 
 [[package]]
@@ -1000,7 +1000,7 @@ files = [
 
 [[package]]
 name = "ipython"
-version = "8.28.0"
+version = "8.29.0"
 requires_python = ">=3.10"
 summary = "IPython: Productive Interactive Computing"
 groups = ["default", "dev", "doc"]
@@ -1018,8 +1018,8 @@ dependencies = [
     "typing-extensions>=4.6; python_version < \"3.12\"",
 ]
 files = [
-    {file = "ipython-8.28.0-py3-none-any.whl", hash = "sha256:530ef1e7bb693724d3cdc37287c80b07ad9b25986c007a53aa1857272dac3f35"},
-    {file = "ipython-8.28.0.tar.gz", hash = "sha256:0d0d15ca1e01faeb868ef56bc7ee5a0de5bd66885735682e8a322ae289a13d1a"},
+    {file = "ipython-8.29.0-py3-none-any.whl", hash = "sha256:0188a1bd83267192123ccea7f4a8ed0a78910535dbaa3f37671dca76ebd429c8"},
+    {file = "ipython-8.29.0.tar.gz", hash = "sha256:40b60e15b22591450eef73e40a027cf77bd652e757523eebc5bd7c7c498290eb"},
 ]
 
 [[package]]
@@ -1373,7 +1373,7 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.12.0"
+version = "1.13.0"
 requires_python = ">=3.8"
 summary = "Optional static typing for Python"
 groups = ["dev", "typing"]
@@ -1383,13 +1383,13 @@ dependencies = [
     "typing-extensions>=4.6.0",
 ]
 files = [
-    {file = "mypy-1.12.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4397081e620dc4dc18e2f124d5e1d2c288194c2c08df6bdb1db31c38cd1fe1ed"},
-    {file = "mypy-1.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:684a9c508a283f324804fea3f0effeb7858eb03f85c4402a967d187f64562469"},
-    {file = "mypy-1.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cabe4cda2fa5eca7ac94854c6c37039324baaa428ecbf4de4567279e9810f9e"},
-    {file = "mypy-1.12.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:060a07b10e999ac9e7fa249ce2bdcfa9183ca2b70756f3bce9df7a92f78a3c0a"},
-    {file = "mypy-1.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:0eff042d7257f39ba4ca06641d110ca7d2ad98c9c1fb52200fe6b1c865d360ff"},
-    {file = "mypy-1.12.0-py3-none-any.whl", hash = "sha256:fd313226af375d52e1e36c383f39bf3836e1f192801116b31b090dfcd3ec5266"},
-    {file = "mypy-1.12.0.tar.gz", hash = "sha256:65a22d87e757ccd95cbbf6f7e181e6caa87128255eb2b6be901bb71b26d8a99d"},
+    {file = "mypy-1.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6607e0f1dd1fb7f0aca14d936d13fd19eba5e17e1cd2a14f808fa5f8f6d8f60a"},
+    {file = "mypy-1.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8a21be69bd26fa81b1f80a61ee7ab05b076c674d9b18fb56239d72e21d9f4c80"},
+    {file = "mypy-1.13.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b2353a44d2179846a096e25691d54d59904559f4232519d420d64da6828a3a7"},
+    {file = "mypy-1.13.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0730d1c6a2739d4511dc4253f8274cdd140c55c32dfb0a4cf8b7a43f40abfa6f"},
+    {file = "mypy-1.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:c5fc54dbb712ff5e5a0fca797e6e0aa25726c7e72c6a5850cfd2adbc1eb0a372"},
+    {file = "mypy-1.13.0-py3-none-any.whl", hash = "sha256:9c250883f9fd81d212e0952c92dbfcc96fc237f4b7c92f56ac81fd48460b3e5a"},
+    {file = "mypy-1.13.0.tar.gz", hash = "sha256:0291a61b6fbf3e6673e3405cfcc0e7650bebc7939659fdca2702958038bd835e"},
 ]
 
 [[package]]
@@ -1568,14 +1568,14 @@ files = [
 
 [[package]]
 name = "one-api"
-version = "2.9.1"
+version = "2.11.1"
 requires_python = ">=3.7"
 summary = "Open Neurophysiology Environment"
 groups = ["default"]
 dependencies = [
     "boto3",
     "flake8>=3.7.8",
-    "iblutil>=1.1.0",
+    "iblutil>=1.13.0",
     "numpy>=1.18",
     "packaging",
     "pandas>=1.5.0",
@@ -1584,8 +1584,8 @@ dependencies = [
     "tqdm>=4.32.1",
 ]
 files = [
-    {file = "ONE_api-2.9.1-py3-none-any.whl", hash = "sha256:d1249e33967edbbd5cc853be2fecc16074fed804418b22940b32b1341fdac36c"},
-    {file = "one_api-2.9.1.tar.gz", hash = "sha256:31e8f72a542ab0a1207003dc631a3251a86e12f72c9107d5754b3ba9a5bd33b3"},
+    {file = "ONE_api-2.11.1-py3-none-any.whl", hash = "sha256:a5a69d3e6324781f8bd46a3c697a68f6ce286ca25f9c9ffb8175a2747a57aa66"},
+    {file = "one_api-2.11.1.tar.gz", hash = "sha256:cb1773f3a06fbf80222d2ea366673a961318951aaf3b640c1fbebbe3ea806a2b"},
 ]
 
 [[package]]
@@ -1618,13 +1618,13 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "24.1"
+version = "24.2"
 requires_python = ">=3.8"
 summary = "Core utilities for Python packages"
 groups = ["default", "ci", "dev", "doc", "test"]
 files = [
-    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
-    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
+    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
+    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
 ]
 
 [[package]]
@@ -1778,10 +1778,10 @@ files = [
 
 [[package]]
 name = "project-extraction"
-version = "0.3.0"
+version = "0.4.0"
 requires_python = "~=3.10"
 git = "https://github.com/int-brain-lab/project_extraction.git"
-revision = "f9b5a45c6a812bf736b6fd5237bfc8d5f3768e2e"
+revision = "c3ae3e2e54072e273cb31d16b04cb264a03ee6f4"
 summary = "Custom extractors for satellite tasks"
 groups = ["project-extraction"]
 
@@ -2175,17 +2175,17 @@ files = [
 
 [[package]]
 name = "pytest-cov"
-version = "5.0.0"
-requires_python = ">=3.8"
+version = "6.0.0"
+requires_python = ">=3.9"
 summary = "Pytest plugin for measuring coverage."
 groups = ["dev", "test"]
 dependencies = [
-    "coverage[toml]>=5.2.1",
+    "coverage[toml]>=7.5",
     "pytest>=4.6",
 ]
 files = [
-    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
-    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
+    {file = "pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0"},
+    {file = "pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35"},
 ]
 
 [[package]]
@@ -2392,29 +2392,29 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.7.0"
+version = "0.7.3"
 requires_python = ">=3.7"
 summary = "An extremely fast Python linter and code formatter, written in Rust."
 groups = ["dev", "test"]
 files = [
-    {file = "ruff-0.7.0-py3-none-linux_armv6l.whl", hash = "sha256:0cdf20c2b6ff98e37df47b2b0bd3a34aaa155f59a11182c1303cce79be715628"},
-    {file = "ruff-0.7.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:496494d350c7fdeb36ca4ef1c9f21d80d182423718782222c29b3e72b3512737"},
-    {file = "ruff-0.7.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:214b88498684e20b6b2b8852c01d50f0651f3cc6118dfa113b4def9f14faaf06"},
-    {file = "ruff-0.7.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:630fce3fefe9844e91ea5bbf7ceadab4f9981f42b704fae011bb8efcaf5d84be"},
-    {file = "ruff-0.7.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:211d877674e9373d4bb0f1c80f97a0201c61bcd1e9d045b6e9726adc42c156aa"},
-    {file = "ruff-0.7.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:194d6c46c98c73949a106425ed40a576f52291c12bc21399eb8f13a0f7073495"},
-    {file = "ruff-0.7.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:82c2579b82b9973a110fab281860403b397c08c403de92de19568f32f7178598"},
-    {file = "ruff-0.7.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9af971fe85dcd5eaed8f585ddbc6bdbe8c217fb8fcf510ea6bca5bdfff56040e"},
-    {file = "ruff-0.7.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b641c7f16939b7d24b7bfc0be4102c56562a18281f84f635604e8a6989948914"},
-    {file = "ruff-0.7.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d71672336e46b34e0c90a790afeac8a31954fd42872c1f6adaea1dff76fd44f9"},
-    {file = "ruff-0.7.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ab7d98c7eed355166f367597e513a6c82408df4181a937628dbec79abb2a1fe4"},
-    {file = "ruff-0.7.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1eb54986f770f49edb14f71d33312d79e00e629a57387382200b1ef12d6a4ef9"},
-    {file = "ruff-0.7.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:dc452ba6f2bb9cf8726a84aa877061a2462afe9ae0ea1d411c53d226661c601d"},
-    {file = "ruff-0.7.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:4b406c2dce5be9bad59f2de26139a86017a517e6bcd2688da515481c05a2cb11"},
-    {file = "ruff-0.7.0-py3-none-win32.whl", hash = "sha256:f6c968509f767776f524a8430426539587d5ec5c662f6addb6aa25bc2e8195ec"},
-    {file = "ruff-0.7.0-py3-none-win_amd64.whl", hash = "sha256:ff4aabfbaaba880e85d394603b9e75d32b0693152e16fa659a3064a85df7fce2"},
-    {file = "ruff-0.7.0-py3-none-win_arm64.whl", hash = "sha256:10842f69c245e78d6adec7e1db0a7d9ddc2fff0621d730e61657b64fa36f207e"},
-    {file = "ruff-0.7.0.tar.gz", hash = "sha256:47a86360cf62d9cd53ebfb0b5eb0e882193fc191c6d717e8bef4462bc3b9ea2b"},
+    {file = "ruff-0.7.3-py3-none-linux_armv6l.whl", hash = "sha256:34f2339dc22687ec7e7002792d1f50712bf84a13d5152e75712ac08be565d344"},
+    {file = "ruff-0.7.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fb397332a1879b9764a3455a0bb1087bda876c2db8aca3a3cbb67b3dbce8cda0"},
+    {file = "ruff-0.7.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:37d0b619546103274e7f62643d14e1adcbccb242efda4e4bdb9544d7764782e9"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d59f0c3ee4d1a6787614e7135b72e21024875266101142a09a61439cb6e38a5"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:44eb93c2499a169d49fafd07bc62ac89b1bc800b197e50ff4633aed212569299"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6d0242ce53f3a576c35ee32d907475a8d569944c0407f91d207c8af5be5dae4e"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:6b6224af8b5e09772c2ecb8dc9f3f344c1aa48201c7f07e7315367f6dd90ac29"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c50f95a82b94421c964fae4c27c0242890a20fe67d203d127e84fbb8013855f5"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7f3eff9961b5d2644bcf1616c606e93baa2d6b349e8aa8b035f654df252c8c67"},
+    {file = "ruff-0.7.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8963cab06d130c4df2fd52c84e9f10d297826d2e8169ae0c798b6221be1d1d2"},
+    {file = "ruff-0.7.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:61b46049d6edc0e4317fb14b33bd693245281a3007288b68a3f5b74a22a0746d"},
+    {file = "ruff-0.7.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:10ebce7696afe4644e8c1a23b3cf8c0f2193a310c18387c06e583ae9ef284de2"},
+    {file = "ruff-0.7.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3f36d56326b3aef8eeee150b700e519880d1aab92f471eefdef656fd57492aa2"},
+    {file = "ruff-0.7.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5d024301109a0007b78d57ab0ba190087b43dce852e552734ebf0b0b85e4fb16"},
+    {file = "ruff-0.7.3-py3-none-win32.whl", hash = "sha256:4ba81a5f0c5478aa61674c5a2194de8b02652f17addf8dfc40c8937e6e7d79fc"},
+    {file = "ruff-0.7.3-py3-none-win_amd64.whl", hash = "sha256:588a9ff2fecf01025ed065fe28809cd5a53b43505f48b69a1ac7707b1b7e4088"},
+    {file = "ruff-0.7.3-py3-none-win_arm64.whl", hash = "sha256:1713e2c5545863cdbfe2cbce21f69ffaf37b813bfd1fb3b90dc9a6f1963f5a8c"},
+    {file = "ruff-0.7.3.tar.gz", hash = "sha256:e1d1ba2e40b6e71a61b063354d04be669ab0d39c352461f3d789cac68b54a313"},
 ]
 
 [[package]]
@@ -2685,7 +2685,7 @@ files = [
 
 [[package]]
 name = "sphinx-lesson"
-version = "0.8.18"
+version = "0.8.19"
 requires_python = ">=3.3"
 summary = "Sphinx extension for CodeRefinery lessons"
 groups = ["dev", "doc"]
@@ -2701,8 +2701,8 @@ dependencies = [
     "sphinx<8",
 ]
 files = [
-    {file = "sphinx_lesson-0.8.18-py3-none-any.whl", hash = "sha256:359df9ec81ae5802d35ea7f18b4ef548e0489942ca61d4560392a8e0c0493c89"},
-    {file = "sphinx_lesson-0.8.18.tar.gz", hash = "sha256:9cb755befd90e1836dc7798113959e86fe7296048a6d88924076cd8215ab1829"},
+    {file = "sphinx_lesson-0.8.19-py3-none-any.whl", hash = "sha256:9f8fe51a61cbcfc3a9b57916abe15dbd4654cb5f0d9d1e7492a37fec27fe95ff"},
+    {file = "sphinx_lesson-0.8.19.tar.gz", hash = "sha256:acf1a75fa38c21cd6e479465e17766f64beb482e4c3874fe8415c44e36261029"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "iblpybpod @ git+https://github.com/int-brain-lab/iblpybpod.git@no-gui",
     "iblutil>=1.13.0",
     "iblqt>=0.2.0",
-    "ONE-api>=2.9.1",
+    "ONE-api>=2.11.0",
     "tycmd-wrapper>=0.2.1",
     #
     # Everything else


### PR DESCRIPTION
In ONE version 3.0.0 `one.alf.files` will be removed but all the same functions will still be available in `one.alf.path`.