### PR TITLE
Save acquisition log for camera sessions (issue #782)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 8.28.0
 ------
 * added: `_iblrig_tasks_spontaneousBpod` - a spontaneous task that includes Bpod spacers
+* added: save acquisistion log for camera sessions
 
 -------------------------------
 

--- a/iblrig/test/test_video.py
+++ b/iblrig/test/test_video.py
@@ -5,7 +5,7 @@ import unittest
 from datetime import date, timedelta
 from pathlib import Path
 from unittest import mock
-from unittest.mock import ANY, MagicMock, call, patch
+from unittest.mock import ANY, DEFAULT, MagicMock, call, patch
 
 import numpy as np
 
@@ -40,6 +40,8 @@ class TestDownloadFunction(unittest.TestCase):
         mock_os_rename.assert_called_once_with(Path('mocked_tmp_file'), expected_out_file)
 
 
+@patch('iblrig.video.HAS_PYSPIN', True)
+@patch('iblrig.video.HAS_SPINNAKER', True)
 class BaseCameraTest(BaseTestCases.CommonTestTask):
     """A base class for camera hardware test fixtures."""
 
@@ -65,8 +67,6 @@ class BaseCameraTest(BaseTestCases.CommonTestTask):
 class TestCameraSession(BaseCameraTest):
     """Test for iblrig.video.CameraSession class."""
 
-    @patch('iblrig.video.HAS_PYSPIN', True)
-    @patch('iblrig.video.HAS_SPINNAKER', True)
     @patch('builtins.input')
     @patch('iblrig.video.call_bonsai')
     @patch('iblrig.video_pyspin.enable_camera_trigger')
@@ -100,6 +100,20 @@ class TestCameraSession(BaseCameraTest):
             call(workflows.recording, expected_pars, debug=False, wait=False),
         ]
         call_bonsai.assert_has_calls(expected)
+        # Check log file initiated and moved to session folder
+        log_file = raw_data_folder.joinpath('_ibl_log.info-acquisition.log')
+        self.assertTrue(log_file.exists() and log_file.stat().st_size > 0)
+        # When file logging fails, there should be a warning
+        with (
+            patch('iblrig.video.setup_logger', side_effect=(DEFAULT, OSError)),
+            self.assertWarns(UserWarning, msg='Failed to set up logs'),
+        ):
+            session = video.CameraSession(**self.task_kwargs)
+        session = video.CameraSession(**self.task_kwargs)
+        with patch.object(session, '_copy_log_to_session', side_effect=OSError), self.assertLogs('iblrig', level='ERROR'):
+            session.run()
+        # Check the original log file still exists
+        self.assertTrue(any(Path(tempfile.gettempdir()).glob('iblrig_logs/????????-??????_camera-session.log')))
 
         # Test validation
         self.assertRaises(NotImplementedError, video.CameraSession, append=True)
@@ -112,6 +126,7 @@ class TestCameraSessionNetworked(unittest.IsolatedAsyncioTestCase, BaseCameraTes
 
     def setUp(self):
         super().setUp()
+        del self.task_kwargs['subject']  # not used in these tests
         # Set up keyboad input mock - simply return empty string as await appears to be blocking
         self.keyboard = ''
         read_stdin = patch('iblrig.video.read_stdin')
@@ -126,6 +141,10 @@ class TestCameraSessionNetworked(unittest.IsolatedAsyncioTestCase, BaseCameraTes
     async def asyncSetUp(self):
         self.communicator = mock.AsyncMock(spec=video.net.app.EchoProtocol)
         self.communicator.is_connected = True
+        self.session = video.CameraSessionNetworked(**self.task_kwargs)
+        # These two lines replace a call to `session.listen`
+        self.session.communicator = self.communicator
+        self.session._status = net.base.ExpStatus.CONNECTED
 
         # Mock the call_bonsai_async function to return an async subprocess mock that awaits a
         # future that we can access via self.bonsai_subprocess_future
@@ -141,23 +160,14 @@ class TestCameraSessionNetworked(unittest.IsolatedAsyncioTestCase, BaseCameraTes
         self.call_bonsai_async.return_value = mock.AsyncMock(spec=asyncio.subprocess.Process)
         self.call_bonsai_async.return_value.wait.side_effect = _wait
 
-    @patch('iblrig.video.HAS_PYSPIN', True)
-    @patch('iblrig.video.HAS_SPINNAKER', True)
     @patch('iblrig.video.call_bonsai')
     @patch('iblrig.video_pyspin.enable_camera_trigger')
     async def test_run_video_session(self, enable_camera_trigger, call_bonsai):
         """Test iblrig.video.CameraSessionNetworked.run method."""
         # Some test hardware settings
-        task_kwargs = self.task_kwargs
-        del task_kwargs['subject']
-        config = task_kwargs['hardware_settings']['device_cameras']['default']
+        config = self.task_kwargs['hardware_settings']['device_cameras']['default']
         workflows = config['BONSAI_WORKFLOW']
-
-        session = video.CameraSessionNetworked(**task_kwargs)
-        # These two lines replace a call to `session.listen`
-        session.communicator = self.communicator
-        session._status = net.base.ExpStatus.CONNECTED
-        self.assertEqual(session.config, config)
+        self.assertEqual(self.session.config, config)
 
         def _end_bonsai_proc():
             """Return args with added side effect of signalling Bonsai subprocess termination."""
@@ -170,41 +180,41 @@ class TestCameraSessionNetworked(unittest.IsolatedAsyncioTestCase, BaseCameraTes
                 match call_number:  # before yielding each message, make some assertions on the current state of the session
                     # Before any messages processed
                     case 0:
-                        self.assertIs(session.status, net.base.ExpStatus.CONNECTED)
-                        self.assertIsNone(session.exp_ref)
+                        self.assertIs(self.session.status, net.base.ExpStatus.CONNECTED)
+                        self.assertIsNone(self.session.exp_ref)
                     # After info message processed
                     case 1:
-                        self.assertIs(session.status, net.base.ExpStatus.CONNECTED)
+                        self.assertIs(self.session.status, net.base.ExpStatus.CONNECTED)
                     # After init message processed
                     case 2:
-                        self.assertIs(session.status, net.base.ExpStatus.INITIALIZED)
-                        self.assertEqual(f'{date.today()}_1_foo', session.exp_ref)
-                        bonsai_task = next((t for t in session._async_tasks if t.get_name() == 'bonsai'), None)
+                        self.assertIs(self.session.status, net.base.ExpStatus.INITIALIZED)
+                        self.assertEqual(f'{date.today()}_1_foo', self.session.exp_ref)
+                        bonsai_task = next((t for t in self.session._async_tasks if t.get_name() == 'bonsai'), None)
                         self.assertIsNotNone(bonsai_task, 'failed to add named bonsai wait task to task set')
                         self.assertFalse(bonsai_task.done(), 'bonsai task unexpectedly cancelled')
                         self.call_bonsai_async.return_value.wait.assert_awaited_once()
                     # After start message processed
                     case 3:
-                        self.assertIs(session.status, net.base.ExpStatus.RUNNING)
+                        self.assertIs(self.session.status, net.base.ExpStatus.RUNNING)
                         # Simulate user ending bonsai subprocess
                         self.bonsai_subprocess_future.set_result(0)
                         # End loop by simulating communicator object disconnecting
                         self.communicator.is_connected = False
                     # case _:
-                    #     self.assertIs(session.status, net.base.ExpStatus.STOPPED)
+                    #     self.assertIs(self.session.status, net.base.ExpStatus.STOPPED)
                 yield msg
 
-        reponses = _end_bonsai_proc()
-        self.communicator.on_event.side_effect = lambda evt: next(reponses)
-        await session.run()
+        responses = _end_bonsai_proc()
+        self.communicator.on_event.side_effect = lambda evt: next(responses)
+        await self.session.run()
         self.communicator.close.assert_called_once()
         self.communicator.on_event.assert_awaited_with(net.base.ExpMessage.any())
-        self.assertEqual(net.base.ExpStatus.STOPPED, session.status)
+        self.assertEqual(net.base.ExpStatus.STOPPED, self.session.status)
 
         # Validate calls
         expected = [call(enable=False), call(enable=True), call(enable=False)]
         enable_camera_trigger.assert_has_calls(expected)
-        raw_data_folder = session.paths['SESSION_RAW_DATA_FOLDER']
+        raw_data_folder = self.session.paths['SESSION_RAW_DATA_FOLDER']
         self.assertTrue(str(raw_data_folder).startswith(str(self.tmp)))
         expected_pars = {
             'LeftCameraIndex': 1,
@@ -218,6 +228,39 @@ class TestCameraSessionNetworked(unittest.IsolatedAsyncioTestCase, BaseCameraTes
             workflows.setup, {'LeftCameraIndex': 1, 'RightCameraIndex': 1}, debug=False, wait=True
         )
         self.call_bonsai_async.assert_awaited_once_with(workflows.recording, expected_pars, debug=False)
+        # Check log file initiated and moved to session folder
+        log_file = raw_data_folder.joinpath('_ibl_log.info-acquisition.log')
+        self.assertTrue(log_file.exists() and log_file.stat().st_size > 0)
+
+    @patch('iblrig.video.call_bonsai')
+    @patch('iblrig.video_pyspin.enable_camera_trigger')
+    async def test_log_move_error(self, *_):
+        """Check handles log move error without raising."""
+        handlers = self.session.logger.handlers
+        handler = next(h for h in handlers if getattr(h, 'baseFilename', '').endswith('_camera-session.log'))
+        temp_log_file = Path(handler.baseFilename)
+        self.assertTrue(temp_log_file.exists() and temp_log_file.is_relative_to(tempfile.gettempdir()))
+
+        def _end_bonsai_proc():
+            """Return args with added side effect of signalling Bonsai subprocess termination."""
+            addr = '192.168.0.5:99998'
+            info_msg = ((net.base.ExpStatus.CONNECTED, {'subject_name': 'foo'}), addr, net.base.ExpMessage.EXPINFO)
+            init_msg = ([{'exp_ref': f'{date.today()}_1_foo'}], addr, net.base.ExpMessage.EXPINIT)
+            start_msg = ((f'{date.today()}_1_foo', {}), addr, net.base.ExpMessage.EXPSTART)
+            status_msg = (net.base.ExpStatus.RUNNING, addr, net.base.ExpMessage.EXPSTATUS)
+            for msg in (info_msg, init_msg, start_msg, status_msg):  # noqa: UP028
+                yield msg
+            # End loop by simulating communicator object disconnecting
+            self.communicator.is_connected = False
+            yield status_msg
+
+        responses = _end_bonsai_proc()
+        self.communicator.on_event.side_effect = lambda evt: next(responses)
+
+        with patch.object(self.session, '_copy_log_to_session', side_effect=OSError), self.assertLogs('iblrig', level='ERROR'):
+            await self.session.run()
+        # Check the original log file still exists
+        self.assertTrue(temp_log_file.exists() and temp_log_file.stat().st_size > 0)
 
 
 class TestValidateVideo(unittest.TestCase):

--- a/iblrig/test/test_video.py
+++ b/iblrig/test/test_video.py
@@ -302,7 +302,7 @@ class TestCameraSessionNetworked(unittest.IsolatedAsyncioTestCase, BaseCameraTes
         with self.assertLogs(self.session.logger.name, 'ERROR') as cm:
             await self.session.run()
             record = next((r.getMessage() for r in cm.records if r.levelno == 40), '')
-            self.assertRegex(record, '2020-01-01_1_bar received; already running 2025-03-12_1_foo')
+            self.assertRegex(record, r'2020-01-01_1_bar received; already running [\d\-_]+foo')
 
     async def test_process_keyboard_input(self):
         """Test iblrig.video.CameraSessionNetworked._process_keyboard_input method."""

--- a/iblrig/test/test_video.py
+++ b/iblrig/test/test_video.py
@@ -2,7 +2,7 @@ import asyncio
 import sys
 import tempfile
 import unittest
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from unittest import mock
 from unittest.mock import ANY, DEFAULT, MagicMock, call, patch
@@ -261,6 +261,94 @@ class TestCameraSessionNetworked(unittest.IsolatedAsyncioTestCase, BaseCameraTes
             await self.session.run()
         # Check the original log file still exists
         self.assertTrue(temp_log_file.exists() and temp_log_file.stat().st_size > 0)
+
+    @patch('iblrig.video.call_bonsai')
+    @patch('iblrig.video_pyspin.enable_camera_trigger')
+    async def test_error_handling(self, *_):
+        """Check handles message errors when running."""
+
+        def _message_mock_1():
+            """Mock two init messages in a row, both with different expRefs."""
+            addr = '192.168.0.5:99998'
+            for ref in ('2020-01-01_1_foo', '2020-01-01_1_bar'):
+                yield [{'exp_ref': ref}], addr, net.base.ExpMessage.EXPINIT
+
+        responses_1 = _message_mock_1()
+        self.communicator.on_event.side_effect = lambda evt: next(responses_1)
+
+        with self.assertRaises(AssertionError) as cm:
+            await self.session.run()
+            self.assertEqual(str(cm.exception), 'expected 2025-03-12_1_foo, got 2025-03-12_1_bar')
+        # Check the communicator was closed
+        self.communicator.close.assert_called_once()
+        self.assertFalse(any(self.session._async_tasks))
+
+        # When the session is running, the communicator should remain open
+        await self.asyncSetUp()  # reset the session
+
+        def _message_mock_2():
+            """Mock two init messages in a row, both with different expRefs."""
+            addr = '192.168.0.5:99998'
+            yield (f'{date.today()}_1_foo', {}), addr, net.base.ExpMessage.EXPSTART
+            while True:  # sometimes the on_event method is awaited again before the bonsai task
+                yield [{'exp_ref': '2020-01-01_1_bar'}], addr, net.base.ExpMessage.EXPINIT
+                if not self.bonsai_subprocess_future.done():
+                    self.bonsai_subprocess_future.set_result(0)
+                    self.communicator.is_connected = False
+
+        responses_2 = _message_mock_2()
+        self.communicator.on_event.side_effect = lambda evt: next(responses_2)
+        # Should catch and log error instead of raising
+        with self.assertLogs(self.session.logger.name, 'ERROR') as cm:
+            await self.session.run()
+            record = next((r.getMessage() for r in cm.records if r.levelno == 40), '')
+            self.assertRegex(record, '2020-01-01_1_bar received; already running 2025-03-12_1_foo')
+
+    async def test_process_keyboard_input(self):
+        """Test iblrig.video.CameraSessionNetworked._process_keyboard_input method."""
+        # With blank input should simply return
+        with self.assertNoLogs(self.session.logger, 'INFO'):
+            await self.session._process_keyboard_input('')
+        self.communicator.close.assert_not_called()
+        # With unknown input should log error
+        with self.assertLogs(self.session.logger, 'ERROR'):
+            await self.session._process_keyboard_input('FOO')
+            self.communicator.close.assert_not_called()
+        # With STOP should log info and stop recording
+        with self.assertLogs(self.session.logger, 'INFO'), patch.object(self.session, 'stop_recording') as stop:
+            await self.session._process_keyboard_input('STOP')
+            stop.assert_awaited_once()
+            self.communicator.close.assert_not_called()
+        # With START should log info and start recording
+        assert self.session.exp_ref is None
+        with self.assertLogs(self.session.logger, 'ERROR'), patch.object(self.session, 'on_start') as start:
+            await self.session._process_keyboard_input('START')
+            start.assert_not_awaited()
+        self.session.session_info = dict(SUBJECT_NAME='foo', SESSION_START_TIME=datetime.now().isoformat(), SESSION_NUMBER=1)
+        assert self.session.exp_ref
+        with self.assertLogs(self.session.logger, 'INFO'), patch.object(self.session, 'on_start') as start:
+            await self.session._process_keyboard_input('START')
+            exp_ref = f'{date.today()}_1_foo'
+            start.assert_awaited_once_with([exp_ref, {}], None)
+        # With QUIT should log info and close communicator
+        with self.assertLogs(self.session.logger, 'INFO'), patch.object(self.session, 'stop_recording') as stop:
+            await self.session._process_keyboard_input('QUIT')
+            stop.assert_not_awaited()
+            self.communicator.close.assert_called()
+            self.session.bonsai_process = MagicMock()
+            self.session.bonsai_process.returncode = 0
+            await self.session._process_keyboard_input('QUIT')
+            stop.assert_not_awaited()
+            self.session.bonsai_process.returncode = None
+            await self.session._process_keyboard_input('QUIT')
+            stop.assert_awaited_once()
+        # With QUIT! should call close method
+        self.communicator.close.reset_mock()
+        with self.assertLogs(self.session.logger, 'INFO'), patch.object(self.session, 'close', wraps=self.session.close) as close:
+            await self.session._process_keyboard_input('QUIT!!!')
+            close.assert_called_once()
+            self.communicator.close.assert_called_once()
+            self.assertFalse(any(self.session._async_tasks))
 
 
 class TestValidateVideo(unittest.TestCase):

--- a/iblrig/video.py
+++ b/iblrig/video.py
@@ -5,7 +5,10 @@ import logging
 import os
 import subprocess
 import sys
+import tempfile
+import warnings
 import zipfile
+from datetime import datetime
 from pathlib import Path
 
 from ibllib.io.raw_data_loaders import load_embedded_frame_data
@@ -192,10 +195,7 @@ def prepare_video_session_cmd():
         parser.error('--subject-name is mandatory if --service-uri has not been provided.')
 
     log_level = 'DEBUG' if args.debug else 'INFO'
-    setup_logger(name='iblrig', level=log_level)
     service_uri = args.service_uri
-    # Technically `prepare_video_service` should behave the same as `prepare_video_session` if the service_uri arg is
-    # False but until fully tested, let's call the old function
     if service_uri is False:
         session = CameraSession(subject=args.subject_name, config_name=args.profile, log_level=log_level)
         session.run()
@@ -320,6 +320,14 @@ class CameraSession(EmptySession):
         if kwargs.get('append'):
             raise NotImplementedError
         super().__init__(subject=subject or '', **kwargs)
+        try:  # Attempt to create log
+            log_file = Path(tempfile.gettempdir()).joinpath(
+                'iblrig_logs', f'{datetime.now().strftime("%Y%m%d-%H%M%S")}_camera-session.log'
+            )
+            log_file.parent.mkdir(parents=True, exist_ok=True)
+            self._setup_loggers(level=kwargs.get('log_level', 'INFO'), file=log_file)
+        except Exception as ex:
+            warnings.warn(f'Failed to set up logs: {ex}', stacklevel=2)
         self.experiment_description = None
         self.bonsai_process = None
         try:
@@ -369,8 +377,28 @@ class CameraSession(EmptySession):
             self._one = OneAlyx(silent=True, mode='local')
         return self._one
 
-    def _setup_loggers(self, level='INFO', **_):
-        self.logger = setup_logger(name='iblrig', level=level)
+    def _setup_loggers(self, level='INFO', file=None, **_):
+        self.logger = setup_logger(name='iblrig', level=level, file=file)
+
+    def _copy_log_to_session(self):
+        """Copy the log file to the session folder.
+
+        This copies the iblrig_logs file handler to the session raw video data folder after closing and removing.
+        This should be run at the end of an acquisition. If no file handler is found or the SESSION_RAW_DATA_FOLDER
+        path is not set, the method will do nothing.
+        """
+        tmplog = Path(tempfile.gettempdir(), 'iblrig_logs')
+        file_handlers = filter(
+            lambda h: isinstance(h, logging.FileHandler) and Path(h.baseFilename).is_relative_to(tmplog), self.logger.handlers
+        )
+        if file_handler := next(file_handlers, None):
+            file_handler.close()
+            self.logger.removeHandler(file_handler)
+            if self.paths.get('SESSION_RAW_DATA_FOLDER'):
+                new_file = self.paths['SESSION_RAW_DATA_FOLDER'].joinpath('_ibl_log.info-acquisition.log')
+                new_file.parent.mkdir(parents=True, exist_ok=True)
+                self.logger.debug('Moving log file: %s -> %s', file_handler.baseFilename, new_file)
+                Path(file_handler.baseFilename).replace(new_file)
 
     @property
     def cameras(self):
@@ -443,6 +471,10 @@ class CameraSession(EmptySession):
         self.bonsai_process.wait()
         self._status = net.base.ExpStatus.STOPPED
         self.stop_recording()
+        try:
+            self._copy_log_to_session()
+        except Exception as ex:
+            self.logger.error('Failed to copy log to session: %s', ex)
 
 
 class CameraSessionNetworked(CameraSession):
@@ -555,6 +587,10 @@ class CameraSessionNetworked(CameraSession):
                         raise NotImplementedError(f'Unexpected task "{task.get_name()}"')
                 self._async_tasks.remove(task)
         self.close()
+        try:
+            self._copy_log_to_session()
+        except Exception as ex:
+            self.logger.error('Failed to copy log to session: %s', ex)
 
     def close(self):
         """End experiment and cleanup object.

--- a/iblrig/video.py
+++ b/iblrig/video.py
@@ -551,6 +551,7 @@ class CameraSessionNetworked(CameraSession):
             await self.listen(service_uri)
         self.run_setup_workflow()
         while self.is_connected:
+            # TODO Add a check here with an attempt to reconnect if not connected and Bonsai workflow is running
             # FIXME Run this as worker for asynchronicity
             # Ensure we are awaiting a message from the remote rig.
             # This task must be re-added each time a message is received.
@@ -572,7 +573,17 @@ class CameraSessionNetworked(CameraSession):
                             self.logger.error('Remote communicator closed')
                             break  # TODO cleanup and interact with com closed callbacks
                         else:
-                            await self._process_message(*task.result())
+                            try:
+                                await self._process_message(*task.result())
+                            except Exception as ex:
+                                if self.status is net.base.ExpStatus.RUNNING:
+                                    # If running, keep connected and log error
+                                    # The behaviour rig can still connect at a later point
+                                    self.logger.error('Failed to process message: %s', ex)
+                                else:
+                                    # If not running raise the exception after closing communicator
+                                    self.close()
+                                    raise ex
                     case 'bonsai':
                         # Bonsai process was ended, most likely it was closed
                         status = task.result()
@@ -584,7 +595,7 @@ class CameraSessionNetworked(CameraSession):
                         self.finalize_recording()
                         # TODO We could send a message to remote here
                     case _:
-                        raise NotImplementedError(f'Unexpected task "{task.get_name()}"')
+                        self.logger.error(f'Unexpected task "{task.get_name()}"')
                 self._async_tasks.remove(task)
         self.close()
         try:
@@ -624,7 +635,7 @@ class CameraSessionNetworked(CameraSession):
         if name.startswith('exp'):
             name = name[3:]
         fcn = getattr(self, 'on_' + name, None)
-        assert callable(fcn)
+        assert callable(fcn), f'on_{name} is not a callable method'
         await fcn(data, addr)
 
     async def _process_keyboard_input(self, line):
@@ -637,8 +648,8 @@ class CameraSessionNetworked(CameraSession):
                 await self.stop_recording()
             case 'QUIT':
                 self.communicator.close()
-                process_finished = self.bonsai_process and self.bonsai_process.returncode is not None
-                if not (self.status is net.base.ExpStatus.STOPPED and process_finished):
+                process_running = self.bonsai_process and self.bonsai_process.returncode is None
+                if process_running and self.status is not net.base.ExpStatus.STOPPED:
                     await self.stop_recording()
             case line if line.startswith('QUIT!'):
                 self.close()
@@ -654,31 +665,59 @@ class CameraSessionNetworked(CameraSession):
             case _:
                 self.logger.error('Command "%s" not recognized. Options: "START", "QUIT" or "QUIT!"', line)
 
+    async def _init(self, exp_ref):
+        """Initialize the recording.
+
+        This should be called by on_init but may be called by on_start if EXPSTART received before EXPINIT
+        or user manually starts session with START.
+
+        Parameters
+        ----------
+        exp_ref : dict
+            The exp_ref to initialize.
+        """
+        current_subject_name = self.session_info['SUBJECT_NAME']  # subject passed in by user (if any)
+        subject_name = exp_ref['subject']
+        assert not current_subject_name or (current_subject_name == subject_name), (
+            f'subject mismatch: {current_subject_name} != {subject_name}'
+        )
+        self._init_paths(exp_ref)
+        await self.initialize_recording()
+        assert self.session_info['SUBJECT_NAME'] == subject_name, (
+            f'subject mismatch: {self.session_info["SUBJECT_NAME"]} != {subject_name}'
+        )
+
     async def on_init(self, data, addr):
-        """Process init command from remote rig."""
+        """Process init command from remote rig.
+
+        This method will initialize the recording and send a response to the remote rig. If an acquisition is already
+        running it will assert that the received experiment description matches the current one (this should be the
+        case when running chained protocols). If the expRef is wrong, the method will raise an error before responding,
+        which should be caught by the calling run method.  Thus one should be able to re-start the behaviour session
+        with the correct subject expRef or turn off UDPs at the behaviour rig without affecting the camera session.
+        """
         self.logger.info('INIT message received')
         data = data[0] if any(data) else {}
-        assert (exp_ref := data.get('exp_ref')), (
-            'No experiment reference found'
-        )  # FIXME graceful error (stop thread somehow so there's no hanging)
-        if isinstance(exp_ref, str):
+        if not (exp_ref := data.get('exp_ref')):
+            raise ValueError('No experiment reference included with EXPINIT data')
+        elif not self.one.is_exp_ref(exp_ref):
+            raise ValueError(f'Invalid experiment reference included with EXPINIT data: {exp_ref}')
+        else:
             exp_ref = self.one.ref2dict(exp_ref)
         # NB: Only the first match case for which predicate is true will be run so we can update the status dynamically
         match self.status:
             case net.base.ExpStatus.CONNECTED:
-                subject_name = self.session_info['SUBJECT_NAME']
-                assert not subject_name or (subject_name == exp_ref['subject'])
-                self._init_paths(exp_ref)
-                await self.initialize_recording()
-                assert self.session_info['SUBJECT_NAME'] == exp_ref['subject']
+                await self._init(exp_ref)
                 self.logger.info('initialized.')
             case net.base.ExpStatus.RUNNING:
                 # Already running - this is fine so long as the exp refs match
-                assert self.exp_ref == self.one.dict2ref(exp_ref)
                 self.logger.warning('received init message while already running.')
+                assert self.exp_ref == self.one.dict2ref(exp_ref), (
+                    f'INIT message for {self.one.dict2ref(exp_ref)} received; already running {self.exp_ref}'
+                )
             case net.base.ExpStatus.INITIALIZED:
                 # Already initialized - this is fine so long as the exp refs match
-                assert self.exp_ref == self.one.dict2ref(exp_ref)
+                assert self.exp_ref == self.one.dict2ref(exp_ref), f'expected {self.exp_ref}, got {self.one.dict2ref(exp_ref)}'
                 self.logger.warning('received init message while already initialized.')
             case net.base.ExpStatus.STOPPED:
                 """
@@ -702,12 +741,10 @@ class CameraSessionNetworked(CameraSession):
             exp_ref = self.one.ref2dict(exp_ref)
         match self.status:
             case S.CONNECTED:
-                self.logger.error('Received EXPSTART before EXPINIT')
-                subject_name = self.session_info['SUBJECT_NAME']
-                assert not subject_name or (subject_name == exp_ref['subject'])
-                self._init_paths(exp_ref)
-                await self.initialize_recording()
-                assert self.session_info['SUBJECT_NAME'] == exp_ref['subject']
+                self.logger.warning(
+                    'Received EXPSTART before EXPINIT'
+                )  # this is fine is user manually starts session via keyboard
+                await self._init(exp_ref)
                 self.start_recording()
             case S.INITIALIZED:
                 self.logger.info('START message received')


### PR DESCRIPTION
This saves a log file to `/tmp/iblrig_logs/YYYYMMDD-HHMMSS_camera-session.log` then at the end of run, copies it to `raw_video_data/_ibl_log.info-acquisition.log`.  This is required because the session path is not known until the session is started. 