### PR TITLE
changed logging level that reports the state of the copier

### DIFF
--- a/iblrig/commands.py
+++ b/iblrig/commands.py
@@ -279,7 +279,7 @@ def transfer_data(
     copiers = _get_copiers(copier, local_subject_folder, remote_subject_folder, interactive=interactive, tag=tag, **kwargs)
 
     for copier in copiers:
-        logger.critical(f'{copier.state}, {copier.session_path}')
+        logger.info(f'\033[1m{copier.state}, {copier.session_path}\033[1m')
         if not dry:
             copier.run(number_of_expected_devices=expected_devices)
 


### PR DESCRIPTION
this was set to critical before, however this is misleading becaues the log is triggered under normal operation. https://docs.python.org/3/howto/logging.html

Added bold printing for highlighting if that was the original intended use