### PR TITLE
Bugfix. Copy log session from one drive to another

### DIFF
--- a/iblrig/video.py
+++ b/iblrig/video.py
@@ -3,6 +3,7 @@ import asyncio
 import contextlib
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -401,7 +402,7 @@ class CameraSession(EmptySession):
                 new_file = self.paths['SESSION_RAW_DATA_FOLDER'].joinpath('_ibl_log.info-acquisition.log')
                 new_file.parent.mkdir(parents=True, exist_ok=True)
                 self.logger.debug('Moving log file: %s -> %s', file_handler.baseFilename, new_file)
-                Path(file_handler.baseFilename).replace(new_file)
+                shutil.move(file_handler.baseFilename, new_file)
 
     @property
     def cameras(self):


### PR DESCRIPTION
After updating iblrig, my video PC now errors at the end of the session when trying to copy the log file to the proper session folder. It failed because my data folder is on a different drive than the temp folder on the OS drive. 