### PR TITLE
Snapshot of Online Plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+8.30.0
+------
+* added: Online Plots are stored as PNG and added to Alyx as a Session Note
+
 8.29.0
 ------
 * added: GUI settings for changing MAIN_SYNC

--- a/iblrig/base_choice_world.py
+++ b/iblrig/base_choice_world.py
@@ -4,8 +4,8 @@ import abc
 import enum
 import logging
 import math
+import multiprocessing
 import random
-import subprocess
 import time
 from pathlib import Path
 from re import split as re_split
@@ -19,6 +19,7 @@ from pydantic import NonNegativeFloat, NonNegativeInt
 
 import iblrig.base_tasks
 from iblrig import choiceworld, misc
+from iblrig.gui.online_plots import online_plots_app
 from iblrig.hardware import DTYPE_AMBIENT_SENSOR_BIN, SOFTCODE
 from iblrig.pydantic_definitions import TrialDataModel
 from iblutil.io import binary, jsonable
@@ -801,7 +802,8 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
     """
 
     TrialDataModel = ActiveChoiceWorldTrialData
-    plot_subprocess: subprocess.Popen | None = None
+    stop_event: multiprocessing.Event() | None = None
+    plot_process: multiprocessing.Process | None = None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -811,22 +813,27 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
         # starts online plotting
         if self.interactive:
             log.info('Starting subprocess: online plots')
-            self.plot_subprocess = subprocess.Popen(
-                ['view_session', str(self.paths['SESSION_RAW_DATA_FOLDER'])],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.STDOUT,
+            self.plot_process = multiprocessing.Process(
+                target=online_plots_app,
+                name='online_plots_app',
+                kwargs={
+                    'session': self.paths['SESSION_RAW_DATA_FOLDER'],
+                    'stop_event': self.stop_event,
+                },
             )
+            self.plot_process.start()
         super()._run()
 
     def _finalize(self):
-        if isinstance(self.plot_subprocess, subprocess.Popen) and self.plot_subprocess.poll() is None:
-            log.info('Terminating subprocess: online plots')
-            self.plot_subprocess.terminate()
-            try:
-                self.plot_subprocess.wait(timeout=5)
-            except subprocess.TimeoutExpired:
+        if isinstance(self.plot_process, multiprocessing.Process):
+            log.info('Signaling online plots process to exit')
+            self.stop_event.set()
+            self.plot_process.join(timeout=5)
+            if self.plot_process.is_alive():
                 log.warning('Process did not terminate within 5 seconds - killing it.')
-                self.plot_subprocess.kill()
+                self.plot_process.kill()
+            self.plot_process = None
+            self.stop_event = None
 
     def show_trial_log(self, extra_info: dict[str, Any] | None = None, log_level: int = logging.INFO):
         # construct info dict

--- a/iblrig/base_choice_world.py
+++ b/iblrig/base_choice_world.py
@@ -822,6 +822,7 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
                 kwargs={
                     'session': self.paths['SESSION_RAW_DATA_FOLDER'],
                     'stop_event': self.stop_event,
+                    'live': True,
                 },
             )
             self.plot_process.start()
@@ -830,7 +831,7 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
         super()._run()
 
         # stop online plotting
-        if isinstance(self.plot_process, multiprocessing.Process):
+        if self.interactive:
             log.info('Signaling online plots process to exit')
             self.stop_event.set()
             self.plot_process.join(timeout=5)
@@ -851,7 +852,6 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
                 register_snapshot = True
                 shutil.move(path_plot, new_path)
                 path_plot = new_path
-                log.info(f'Moved snapshot of online plots to {path_plot}')
 
         # call register_to_alyx of super class
         session = super().register_to_alyx()

--- a/iblrig/base_choice_world.py
+++ b/iblrig/base_choice_world.py
@@ -24,6 +24,7 @@ from iblrig.hardware import DTYPE_AMBIENT_SENSOR_BIN, SOFTCODE
 from iblrig.pydantic_definitions import TrialDataModel
 from iblutil.io import binary, jsonable
 from iblutil.util import Bunch
+from one.api import OneAlyx
 from pybpodapi.com.messaging.trial import Trial
 from pybpodapi.protocol import StateMachine
 
@@ -791,12 +792,12 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
     The ActiveChoiceWorldSession is a base class for protocols where the mouse is actively making decisions
     by turning the wheel. It has the following characteristics
 
-    -   it is trial based
-    -   it is decision based
-    -   left and right simulus are equiprobable: there is no biased block
-    -   a trial can either be correct / error / no_go depending on the side of the stimulus and the response
-    -   it has a quantifiable performance by computing the proportion of correct trials of passive stimulations protocols or
-        habituation protocols.
+    - it is trial based
+    - it is decision based
+    - left and right simulus are equiprobable: there is no biased block
+    - a trial can either be correct / error / no_go depending on the side of the stimulus and the response
+    - it has a quantifiable performance by computing the proportion of correct trials of passive stimulations protocols or
+      habituation protocols.
 
     The TrainingChoiceWorld, BiasedChoiceWorld are all subclasses of this class
     """
@@ -810,7 +811,7 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
         self.trials_table['stim_probability_left'] = np.zeros(NTRIALS_INIT, dtype=np.float64)
 
     def _run(self):
-        # starts online plotting
+        # start online plotting
         if self.interactive:
             log.info('Starting subprocess: online plots')
             self.plot_process = multiprocessing.Process(
@@ -822,9 +823,11 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
                 },
             )
             self.plot_process.start()
+
+        # run super method
         super()._run()
 
-    def _finalize(self):
+        # stop online plotting
         if isinstance(self.plot_process, multiprocessing.Process):
             log.info('Signaling online plots process to exit')
             self.stop_event.set()
@@ -834,6 +837,24 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
                 self.plot_process.kill()
             self.plot_process = None
             self.stop_event.clear()
+
+    def register_to_alyx(self) -> dict | None:
+        session = super().register_to_alyx()
+
+        # set online plot as note
+        path_plot = self.paths['SESSION_RAW_DATA_FOLDER'] / '_iblrig_onlinePlots.png'
+        if session is not None and path_plot.exists() and isinstance(self.one, OneAlyx):
+            client = self.one.alyx
+            note = {
+                'user': self.iblrig_settings.ALYX_USER,
+                'content_type': 'session',
+                'object_id': session['id'],
+                'text': 'Snapshot of Online Plot',
+            }
+            with path_plot.open('rb') as img_file:
+                client.rest('notes', 'create', data=note, files={'image': img_file})
+
+        return session
 
     def show_trial_log(self, extra_info: dict[str, Any] | None = None, log_level: int = logging.INFO):
         # construct info dict

--- a/iblrig/base_choice_world.py
+++ b/iblrig/base_choice_world.py
@@ -6,6 +6,7 @@ import logging
 import math
 import multiprocessing
 import random
+import shutil
 import time
 from pathlib import Path
 from re import split as re_split
@@ -840,14 +841,25 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
             self.stop_event.clear()
 
     def register_to_alyx(self) -> dict | None:
+        # move online plots to session folder
+        register_snapshot = False
+        path_plot: Path = self.paths['SESSION_RAW_DATA_FOLDER'] / 'online_plots.png'
+        suffix = self.paths['SESSION_RAW_DATA_FOLDER'].name[-2:]
+        if path_plot.exists():
+            new_path = self.paths['SESSION_FOLDER'] / f'online_plots_{suffix}.png'
+            if not new_path.exists():
+                register_snapshot = True
+                shutil.move(path_plot, new_path)
+                path_plot = new_path
+                log.info(f'Moved snapshot of online plots to {path_plot}')
+
+        # call register_to_alyx of super class
         session = super().register_to_alyx()
 
         # register online plot as session note
-        path_plot = self.paths['SESSION_RAW_DATA_FOLDER'] / '_iblrig_onlinePlots.png'
-        if session is not None and path_plot.exists() and isinstance(self.one, OneAlyx) and self.one.alyx.is_logged_in:
+        if register_snapshot and session is not None and isinstance(self.one, OneAlyx) and self.one.alyx.is_logged_in:
             snapshot = Snapshot(object_id=session['id'], content_type='session', one=self.one)
-            snapshot.register_image(image_file=path_plot, text='Snapshot of Online Plot', width='orig')
-            log.info('Registering snapshot of online plot as session note')
+            snapshot.register_image(image_file=path_plot, text=f'Snapshot of Online Plots #{suffix}', width='orig')
 
         return session
 

--- a/iblrig/base_choice_world.py
+++ b/iblrig/base_choice_world.py
@@ -802,7 +802,7 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
     """
 
     TrialDataModel = ActiveChoiceWorldTrialData
-    stop_event: multiprocessing.Event() | None = None
+    stop_event: multiprocessing.Event | None = None
     plot_process: multiprocessing.Process | None = None
 
     def __init__(self, **kwargs):

--- a/iblrig/base_choice_world.py
+++ b/iblrig/base_choice_world.py
@@ -18,6 +18,7 @@ from annotated_types import Interval, IsNan
 from pydantic import NonNegativeFloat, NonNegativeInt
 
 import iblrig.base_tasks
+from ibllib.plots.snapshot import Snapshot
 from iblrig import choiceworld, misc
 from iblrig.gui.online_plots import online_plots_app
 from iblrig.hardware import DTYPE_AMBIENT_SENSOR_BIN, SOFTCODE
@@ -841,18 +842,12 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
     def register_to_alyx(self) -> dict | None:
         session = super().register_to_alyx()
 
-        # set online plot as note
+        # register online plot as session note
         path_plot = self.paths['SESSION_RAW_DATA_FOLDER'] / '_iblrig_onlinePlots.png'
-        if session is not None and path_plot.exists() and isinstance(self.one, OneAlyx):
-            client = self.one.alyx
-            note = {
-                'user': self.iblrig_settings.ALYX_USER,
-                'content_type': 'session',
-                'object_id': session['id'],
-                'text': 'Snapshot of Online Plot',
-            }
-            with path_plot.open('rb') as img_file:
-                client.rest('notes', 'create', data=note, files={'image': img_file})
+        if session is not None and path_plot.exists() and isinstance(self.one, OneAlyx) and self.one.alyx.is_logged_in:
+            snapshot = Snapshot(object_id=session['id'], content_type='session', one=self.one)
+            snapshot.register_image(image_file=path_plot, text='Snapshot of Online Plot', width='orig')
+            log.info('Registering snapshot of online plot as session note')
 
         return session
 

--- a/iblrig/base_choice_world.py
+++ b/iblrig/base_choice_world.py
@@ -802,7 +802,7 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
     """
 
     TrialDataModel = ActiveChoiceWorldTrialData
-    stop_event: multiprocessing.Event | None = None
+    stop_event = multiprocessing.Event()
     plot_process: multiprocessing.Process | None = None
 
     def __init__(self, **kwargs):
@@ -833,7 +833,7 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
                 log.warning('Process did not terminate within 5 seconds - killing it.')
                 self.plot_process.kill()
             self.plot_process = None
-            self.stop_event = None
+            self.stop_event.clear()
 
     def show_trial_log(self, extra_info: dict[str, Any] | None = None, log_level: int = logging.INFO):
         # construct info dict

--- a/iblrig/base_choice_world.py
+++ b/iblrig/base_choice_world.py
@@ -857,9 +857,12 @@ class ActiveChoiceWorldSession(ChoiceWorldSession):
         session = super().register_to_alyx()
 
         # register online plot as session note
-        if register_snapshot and session is not None and isinstance(self.one, OneAlyx) and self.one.alyx.is_logged_in:
-            snapshot = Snapshot(object_id=session['id'], content_type='session', one=self.one)
-            snapshot.register_image(image_file=path_plot, text=f'Snapshot of Online Plots #{suffix}', width='orig')
+        try:
+            if register_snapshot and session is not None and isinstance(self.one, OneAlyx) and self.one.alyx.is_logged_in:
+                snapshot = Snapshot(object_id=session['id'], content_type='session', one=self.one)
+                snapshot.register_image(image_file=path_plot, text=f'Snapshot of Online Plots #{suffix}', width='orig')
+        except Exception as e:
+            log.error('Failed to register online plots as session note', exc_info=e)
 
         return session
 

--- a/iblrig/base_tasks.py
+++ b/iblrig/base_tasks.py
@@ -48,7 +48,7 @@ from iblutil.io.net.base import ExpMessage
 from iblutil.spacer import Spacer
 from iblutil.util import Bunch, flatten, setup_logger
 from one.alf.io import next_num_folder
-from one.api import ONE, OneAlyx
+from one.api import ONE, One, OneAlyx
 from pybpodapi.protocol import StateMachine
 
 OSC_CLIENT_IP = '127.0.0.1'
@@ -590,11 +590,11 @@ class BaseSession(ABC):
         log.debug(f'Trial data dumped to `{self.paths["DATA_FILE_PATH"].name}`')
 
     @property
-    def one(self):
+    def one(self) -> OneAlyx | One | None:
         """ONE getter."""
         if self._one is None:
             if self.iblrig_settings['ALYX_URL'] is None:
-                return
+                return None
             info_str = (
                 f'alyx client with user name {self.iblrig_settings["ALYX_USER"]} '
                 + f'and url: {self.iblrig_settings["ALYX_URL"]}'
@@ -612,13 +612,13 @@ class BaseSession(ABC):
                 log.error('could not connect to ' + info_str)
         return self._one
 
-    def register_to_alyx(self):
+    def register_to_alyx(self) -> dict | None:
         """
         Registers the session to Alyx.
 
         This registers the session using the IBLRegistrationClient class.  This uses the settings
         file(s) and experiment description file to extract the session data.  This may be called
-        any number of times and if the session record already exists in Alyx it will be updated.
+        any number of times, and if the session record already exists in Alyx it will be updated.
         If session registration fails, it will be done before extraction in the ibllib pipeline.
 
         Note that currently the subject weight is registered once and only once.  The recorded
@@ -635,7 +635,7 @@ class BaseSession(ABC):
 
         Returns
         -------
-        dict
+        dict or None
             The registered session record.
 
         See Also
@@ -644,31 +644,34 @@ class BaseSession(ABC):
         """
         if self.session_info['SUBJECT_NAME'] in ('iblrig_test_subject', 'test', 'test_subject'):
             log.warning('Not registering test subject to Alyx')
-            return
+            return None
         if not self.one or self.one.offline:
-            return
+            return None
         try:
             client = IBLRegistrationClient(self.one)
-            ses, _ = client.register_session(self.paths.SESSION_FOLDER, register_reward=False)
-        except Exception:
-            log.error(traceback.format_exc())
-            log.error('Could not register session to Alyx')
-            return
+            session, _ = client.register_session(self.paths['SESSION_FOLDER'], register_reward=False)
+        except Exception as e:
+            log.error('Could not register session to Alyx', exc_info=e)
+            return None
+
         # add the water administration if there was water administered
         try:
             if self.session_info['TOTAL_WATER_DELIVERED']:
-                wa = client.register_water_administration(
-                    self.session_info.SUBJECT_NAME,
+                water_administration_record = client.register_water_administration(
+                    self.session_info['SUBJECT_NAME'],
                     self.session_info['TOTAL_WATER_DELIVERED'] / 1000,
-                    session=ses['url'][-36:],
+                    session=session['url'][-36:],
                     water_type=self.task_params.get('REWARD_TYPE', None),
                 )
-                log.info(f'Water administered registered in Alyx database: {ses["subject"]}, {wa["water_administered"]}mL')
-        except Exception:
-            log.error(traceback.format_exc())
-            log.error('Could not register water administration to Alyx')
-            return
-        return ses
+                log.info(
+                    f'Water administered registered in Alyx database: {session["subject"]},'
+                    f'{water_administration_record["water_administered"]}mL'
+                )
+        except Exception as e:
+            log.error('Could not register water administration to Alyx', exc_info=e)
+            return None
+
+        return session
 
     def _execute_mixins_shared_function(self, pattern: str) -> None:
         """
@@ -1348,7 +1351,7 @@ class NetworkSession(BaseSession):
             raise ex
 
     @property
-    def one(self):
+    def one(self) -> OneAlyx | One:
         """Return ONE instance.
 
         Unlike super class getter, this method will always instantiate ONE, allowing subclasses to update with an Alyx

--- a/iblrig/gui/online_plots.py
+++ b/iblrig/gui/online_plots.py
@@ -1071,7 +1071,7 @@ class OnlinePlotsView(QMainWindow):
     def save_as_png(self, filename: os.PathLike | str) -> None:
         """Save plot as a PNG file."""
         filename = Path(filename).with_suffix('.png')
-        img = self.grab(self.rect())
+        img = self.centralWidget().grab()
         img.save(str(filename), 'PNG')
 
 

--- a/iblrig/gui/online_plots.py
+++ b/iblrig/gui/online_plots.py
@@ -1054,7 +1054,7 @@ class OnlinePlotsView(QMainWindow):
     def closeEvent(self, event):
         if self.model.raw_data_folder is not None:
             self.model.setCurrentTrial(self.model.nTrials() - 1)
-            filename = self.model.raw_data_folder / '_iblrig_online_plots.png'
+            filename = self.model.raw_data_folder / '_iblrig_onlinePlots.png'
             if not filename.exists():
                 self.save_as_png(filename)
         event.accept()

--- a/iblrig/gui/online_plots.py
+++ b/iblrig/gui/online_plots.py
@@ -6,6 +6,7 @@ import time
 from collections.abc import Iterable
 from copy import copy
 from dataclasses import dataclass
+from multiprocessing.synchronize import Event as mpEvent
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -1053,6 +1054,20 @@ class OnlinePlotsView(QMainWindow):
             self.settings.setValue('size', self.size())
         super().resizeEvent(event)
 
+    def closeEvent(self, event):
+        if self.model.raw_data_folder is not None:
+            self.model.setCurrentTrial(self.model.nTrials() - 1)
+            filename = self.model.raw_data_folder / 'online_plots.png'
+            if not filename.exists():
+                self.save_as_png(self.model.raw_data_folder / 'online_plots.png')
+        event.accept()
+
+    def save_as_png(self, filename: os.PathLike | str) -> None:
+        """Save plot as a PNG file."""
+        filename = Path(filename).with_suffix('.png')
+        img = self.grab(self.rect())
+        img.save(str(filename), 'PNG')
+
 
 def online_plots_cli(*args):
     """
@@ -1088,10 +1103,11 @@ def online_plots_cli(*args):
     online_plots_app(session, group)
 
 
+@validate_call
 def online_plots_app(
     session: FilePath | DirectoryPath | UUID4 | None = None,
     group: str | None = None,
-    stop_event=None,
+    stop_event: mpEvent | None = None,
 ) -> None:
     """
     Launch the IBL Online Plots GUI.
@@ -1109,7 +1125,7 @@ def online_plots_app(
     group : str | None, optional
         Name of the data column to group by. If ``None``, the default grouping
         will be used.
-    stop_event : multiprocessing.Event, optional
+    stop_event : multiprocessing.synchronize.Event, optional
         Event to signal graceful shutdown.
     """
     QCoreApplication.setOrganizationName('International Brain Laboratory')

--- a/iblrig/gui/online_plots.py
+++ b/iblrig/gui/online_plots.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import os
 import sys
 import time
@@ -59,6 +60,8 @@ from iblrig.path_helper import get_local_and_remote_paths
 from iblrig.raw_data_loaders import bpod_trial_data_to_dataframe, load_task_jsonable
 from one.alf.spec import is_session_path
 from one.api import ONE
+
+log = logging.getLogger(__name__)
 
 
 def is_alf_path(value: Path) -> Path:
@@ -668,6 +671,7 @@ class OnlinePlotsModel(QObject):
                 while not self.jsonable_file.exists():
                     time.sleep(0.2)
             is_live = True
+            log.info(f'Starting online plots for session {self.raw_data_folder}')
 
         # If session is a file ...
         elif session.is_file():
@@ -1055,6 +1059,7 @@ class OnlinePlotsView(QMainWindow):
         super().resizeEvent(event)
 
     def closeEvent(self, event):
+        log.info('Closing online plots')
         if self.model.raw_data_folder is not None:
             self.model.setCurrentTrial(self.model.nTrials() - 1)
             filename = self.model.raw_data_folder / 'online_plots.png'
@@ -1086,13 +1091,19 @@ def online_plots_cli(*args):
     sys.argv.extend([str(arg) for arg in args])
 
     class CLISettings(
-        BaseSettings, cli_parse_args=True, cli_enforce_required=False, cli_avoid_json=True, cli_hide_none_type=True
+        BaseSettings,
+        cli_parse_args=True,
+        cli_enforce_required=False,
+        cli_avoid_json=True,
+        cli_hide_none_type=True,
     ):
         """Display a Session's Online Plot."""
 
         session: CliPositionalArg[FilePath | DirectoryPath | UUID4] = Field(description="a session's Task Data File or eID")
         group: str | None = Field(
-            description='override the data column to group data by', validation_alias=AliasChoices('g', 'group'), default=None
+            description='override the data column to group data by',
+            validation_alias=AliasChoices('g', 'group'),
+            default=None,
         )
 
     if len(sys.argv) < 2:
@@ -1103,7 +1114,6 @@ def online_plots_cli(*args):
     online_plots_app(session, group)
 
 
-@validate_call
 def online_plots_app(
     session: FilePath | DirectoryPath | UUID4 | None = None,
     group: str | None = None,

--- a/iblrig/gui/online_plots.py
+++ b/iblrig/gui/online_plots.py
@@ -681,9 +681,6 @@ class OnlinePlotsModel(QObject):
         if self.settings_file.exists():
             with self.settings_file.open('r') as f:
                 self.task_settings = json.load(f)
-
-        else:
-            self.grouping_variable = grouping_variable or GROUPING_VARIABLE
         self.grouping_variable = grouping_variable or getattr(self, 'task_settings', {}).get(
             'PLOT_GROUPING_VARIABLE', GROUPING_VARIABLE
         )

--- a/iblrig/gui/online_plots.py
+++ b/iblrig/gui/online_plots.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import logging
 import os
 import sys
 import time
@@ -60,8 +59,6 @@ from iblrig.path_helper import get_local_and_remote_paths
 from iblrig.raw_data_loaders import bpod_trial_data_to_dataframe, load_task_jsonable
 from one.alf.spec import is_session_path
 from one.api import ONE
-
-log = logging.getLogger(__name__)
 
 
 def is_alf_path(value: Path) -> Path:
@@ -671,7 +668,6 @@ class OnlinePlotsModel(QObject):
                 while not self.jsonable_file.exists():
                     time.sleep(0.2)
             is_live = True
-            log.info(f'Starting online plots for session {self.raw_data_folder}')
 
         # If session is a file ...
         elif session.is_file():
@@ -1059,7 +1055,6 @@ class OnlinePlotsView(QMainWindow):
         super().resizeEvent(event)
 
     def closeEvent(self, event):
-        log.info('Closing online plots')
         if self.model.raw_data_folder is not None:
             self.model.setCurrentTrial(self.model.nTrials() - 1)
             filename = self.model.raw_data_folder / 'online_plots.png'
@@ -1162,7 +1157,7 @@ def online_plots_app(
 
     if stop_event is not None:
         timer = QTimer()
-        timer.timeout.connect(lambda: app.quit() if stop_event.is_set() else None)
+        timer.timeout.connect(lambda: window.close() if stop_event.is_set() else None)
         timer.start(500)
 
     sys.exit(app.exec())

--- a/iblrig/gui/online_plots.py
+++ b/iblrig/gui/online_plots.py
@@ -631,10 +631,14 @@ class OnlinePlotsModel(QObject):
 
     @validate_call(config=dict(arbitrary_types_allowed=True))
     def __init__(
-        self, session: FilePath | DirectoryPath | UUID4, grouping_variable: str | None = None, parent: QObject | None = None
+        self,
+        session: FilePath | DirectoryPath | UUID4,
+        grouping_variable: str | None = None,
+        parent: QObject | None = None,
+        live: bool = False,
     ):
         super().__init__(parent=parent)
-        is_live = False
+        self.is_live = live
 
         # If session is a UUID ...
         if not isinstance(session, Path):
@@ -667,7 +671,6 @@ class OnlinePlotsModel(QObject):
                 print('Waiting for data ...')
                 while not self.jsonable_file.exists():
                     time.sleep(0.2)
-            is_live = True
 
         # If session is a file ...
         elif session.is_file():
@@ -704,7 +707,7 @@ class OnlinePlotsModel(QObject):
 
         # read the jsonable file and instantiate a QFileSystemWatcher
         self.readJsonable(self.jsonable_file)
-        if is_live:
+        if self.is_live:
             self.jsonableWatcher = QFileSystemWatcher([str(self.jsonable_file)], parent=self)
             self.jsonableWatcher.fileChanged.connect(self.readJsonable)
 
@@ -857,10 +860,16 @@ class OnlinePlotsModel(QObject):
 class OnlinePlotsView(QMainWindow):
     colormap = pg.colormap.get('tab10', source='matplotlib')
 
-    def __init__(self, session: FilePath | DirectoryPath | UUID4, group_by: str | None = None, parent: QObject | None = None):
+    def __init__(
+        self,
+        session: FilePath | DirectoryPath | UUID4,
+        group_by: str | None = None,
+        parent: QObject | None = None,
+        live: bool = False,
+    ):
         super().__init__(parent)
         pg.setConfigOptions(antialias=True)
-        self.model = OnlinePlotsModel(session=session, grouping_variable=group_by, parent=self)
+        self.model = OnlinePlotsModel(session=session, grouping_variable=group_by, parent=self, live=live)
 
         self.statusBar().clearMessage()
         self.setWindowTitle('Online Plots')
@@ -1052,7 +1061,7 @@ class OnlinePlotsView(QMainWindow):
         super().resizeEvent(event)
 
     def closeEvent(self, event):
-        if self.model.raw_data_folder is not None:
+        if self.model.is_live and self.model.raw_data_folder is not None:
             self.model.setCurrentTrial(self.model.nTrials() - 1)
             filename = self.model.raw_data_folder / 'online_plots.png'
             if not filename.exists():
@@ -1103,13 +1112,14 @@ def online_plots_cli(*args):
     else:
         cli = CLISettings()
         session, group = cli.session, cli.group
-    online_plots_app(session, group)
+    online_plots_app(session=session, group=group)
 
 
 def online_plots_app(
     session: FilePath | DirectoryPath | UUID4 | None = None,
     group: str | None = None,
     stop_event: mpEvent | None = None,
+    live: bool = False,
 ) -> None:
     """
     Launch the IBL Online Plots GUI.
@@ -1129,6 +1139,9 @@ def online_plots_app(
         will be used.
     stop_event : multiprocessing.synchronize.Event, optional
         Event to signal graceful shutdown.
+    live : bool, optional
+        Whether to use live plotting. If ``True``, the GUI will update on
+        changes. Default is ``False``.
     """
     QCoreApplication.setOrganizationName('International Brain Laboratory')
     QCoreApplication.setOrganizationDomain('internationalbrainlab.org')
@@ -1149,7 +1162,7 @@ def online_plots_app(
         if len(session) == 0:
             return
 
-    window = OnlinePlotsView(session, group)
+    window = OnlinePlotsView(session=session, group_by=group, live=live)
     window.show()
 
     if stop_event is not None:

--- a/iblrig/gui/online_plots.py
+++ b/iblrig/gui/online_plots.py
@@ -1,4 +1,3 @@
-import ctypes
 import datetime
 import json
 import os
@@ -1055,6 +1054,19 @@ class OnlinePlotsView(QMainWindow):
 
 
 def online_plots_cli(*args):
+    """
+    Command-line entry point for launching the IBL Online Plots application.
+
+    This function extends ``sys.argv`` with the provided arguments, parses
+    them via a Pydantic CLI settings class, and then invokes
+    :func:`online_plots_app`.
+
+    Parameters
+    ----------
+    *args : Any
+        Additional arguments to simulate command-line input. These will be
+        converted to strings and appended to ``sys.argv``.
+    """
     sys.argv.extend([str(arg) for arg in args])
 
     class CLISettings(
@@ -1067,26 +1079,52 @@ def online_plots_cli(*args):
             description='override the data column to group data by', validation_alias=AliasChoices('g', 'group'), default=None
         )
 
-    # set app information
+    if len(sys.argv) < 2:
+        session, group = None, None
+    else:
+        cli = CLISettings()
+        session, group = cli.session, cli.group
+    online_plots_app(session, group)
+
+
+def online_plots_app(session: FilePath | DirectoryPath | UUID4 | None = None, group: str | None = None) -> None:
+    """
+    Launch the IBL Online Plots GUI.
+
+    This function initializes a Qt application, loads the selected session
+    (or prompts the user to select one if none is provided), and displays the
+    OnlinePlotsView window.
+
+    Parameters
+    ----------
+    session : FilePath | DirectoryPath | UUID4 | None, optional
+        The session data to load. Can be a file path, directory path, UUID, or
+        ``None``. If ``None``, a file dialog will prompt the user to choose a
+        Task Data file.
+    group : str | None, optional
+        Name of the data column to group by. If ``None``, the default grouping
+        will be used.
+    """
     QCoreApplication.setOrganizationName('International Brain Laboratory')
     QCoreApplication.setOrganizationDomain('internationalbrainlab.org')
     QCoreApplication.setApplicationName('IBLRIG Online Plots')
     if os.name == 'nt':
+        import ctypes
+
         app_id = f'IBL.iblrig.online_plots.{iblrig_version}'
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(app_id)
 
     app = QApplication([])
 
-    if len(sys.argv) < 2:
+    if session is None:
         local_subjects_folder = str(get_local_and_remote_paths()['local_subjects_folder'])
         session, _ = QFileDialog.getOpenFileName(
             caption='Select Task Data File', filter='Task Data (*.raw.jsonable)', directory=local_subjects_folder
         )
         if len(session) == 0:
             return
-    else:
-        session = CLISettings().session
-    window = OnlinePlotsView(session, CLISettings().group)
+
+    window = OnlinePlotsView(session, group)
     window.show()
 
     sys.exit(app.exec())

--- a/iblrig/gui/online_plots.py
+++ b/iblrig/gui/online_plots.py
@@ -1057,9 +1057,9 @@ class OnlinePlotsView(QMainWindow):
     def closeEvent(self, event):
         if self.model.raw_data_folder is not None:
             self.model.setCurrentTrial(self.model.nTrials() - 1)
-            filename = self.model.raw_data_folder / 'online_plots.png'
+            filename = self.model.raw_data_folder / '_iblrig_online_plots.png'
             if not filename.exists():
-                self.save_as_png(self.model.raw_data_folder / 'online_plots.png')
+                self.save_as_png(filename)
         event.accept()
 
     def save_as_png(self, filename: os.PathLike | str) -> None:

--- a/iblrig/gui/online_plots.py
+++ b/iblrig/gui/online_plots.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import multiprocessing
 import os
 import sys
 import time
@@ -1092,7 +1091,7 @@ def online_plots_cli(*args):
 def online_plots_app(
     session: FilePath | DirectoryPath | UUID4 | None = None,
     group: str | None = None,
-    stop_event: multiprocessing.Event | None = None,
+    stop_event=None,
 ) -> None:
     """
     Launch the IBL Online Plots GUI.

--- a/iblrig/gui/online_plots.py
+++ b/iblrig/gui/online_plots.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import multiprocessing
 import os
 import sys
 import time
@@ -27,6 +28,7 @@ from qtpy.QtCore import (
     QSize,
     Qt,
     QThreadPool,
+    QTimer,
     Signal,
     Slot,
 )
@@ -1087,7 +1089,11 @@ def online_plots_cli(*args):
     online_plots_app(session, group)
 
 
-def online_plots_app(session: FilePath | DirectoryPath | UUID4 | None = None, group: str | None = None) -> None:
+def online_plots_app(
+    session: FilePath | DirectoryPath | UUID4 | None = None,
+    group: str | None = None,
+    stop_event: multiprocessing.Event | None = None,
+) -> None:
     """
     Launch the IBL Online Plots GUI.
 
@@ -1097,13 +1103,15 @@ def online_plots_app(session: FilePath | DirectoryPath | UUID4 | None = None, gr
 
     Parameters
     ----------
-    session : FilePath | DirectoryPath | UUID4 | None, optional
+    session : FilePath | DirectoryPath | UUID4, optional
         The session data to load. Can be a file path, directory path, UUID, or
         ``None``. If ``None``, a file dialog will prompt the user to choose a
         Task Data file.
     group : str | None, optional
         Name of the data column to group by. If ``None``, the default grouping
         will be used.
+    stop_event : multiprocessing.Event, optional
+        Event to signal graceful shutdown.
     """
     QCoreApplication.setOrganizationName('International Brain Laboratory')
     QCoreApplication.setOrganizationDomain('internationalbrainlab.org')
@@ -1126,6 +1134,11 @@ def online_plots_app(session: FilePath | DirectoryPath | UUID4 | None = None, gr
 
     window = OnlinePlotsView(session, group)
     window.show()
+
+    if stop_event is not None:
+        timer = QTimer()
+        timer.timeout.connect(lambda: app.quit() if stop_event.is_set() else None)
+        timer.start(500)
 
     sys.exit(app.exec())
 

--- a/iblrig/gui/online_plots.py
+++ b/iblrig/gui/online_plots.py
@@ -1054,7 +1054,7 @@ class OnlinePlotsView(QMainWindow):
     def closeEvent(self, event):
         if self.model.raw_data_folder is not None:
             self.model.setCurrentTrial(self.model.nTrials() - 1)
-            filename = self.model.raw_data_folder / '_iblrig_onlinePlots.png'
+            filename = self.model.raw_data_folder / 'online_plots.png'
             if not filename.exists():
                 self.save_as_png(filename)
         event.accept()

--- a/iblrig/test/test_alyx.py
+++ b/iblrig/test/test_alyx.py
@@ -93,7 +93,7 @@ class TestRegisterSession(BaseTestCases.CommonTestTask):
         ):
             self.assertIsNone(chained.register_to_alyx())
             self.assertIn('AssertionError', log.output[0])
-            self.assertIn('Could not register session to Alyx', log.output[])
+            self.assertIn('Could not register session to Alyx', log.output[0])
 
         # An empty session record should cause an error when attempting to register weight
         with (
@@ -101,7 +101,7 @@ class TestRegisterSession(BaseTestCases.CommonTestTask):
             self.assertLogs('iblrig.base_tasks', 'ERROR') as log,
         ):
             self.assertIsNone(chained.register_to_alyx())
-            self.assertIn('Could not register water administration to Alyx', log.output[1])
+            self.assertIn('Could not register water administration to Alyx', log.output[0])
 
         # ONE in offline mode should simply return
         self.one.mode = 'local'

--- a/iblrig/test/test_alyx.py
+++ b/iblrig/test/test_alyx.py
@@ -93,7 +93,7 @@ class TestRegisterSession(BaseTestCases.CommonTestTask):
         ):
             self.assertIsNone(chained.register_to_alyx())
             self.assertIn('AssertionError', log.output[0])
-            self.assertIn('Could not register session to Alyx', log.output[1])
+            self.assertIn('Could not register session to Alyx', log.output[])
 
         # An empty session record should cause an error when attempting to register weight
         with (

--- a/iblrig/test/test_online_plots.py
+++ b/iblrig/test/test_online_plots.py
@@ -25,7 +25,7 @@ class TestOnlinePlots:
         temp_dir.cleanup()
 
     def test_during_task(self, task_file, qtbot):
-        view = op.OnlinePlotsView(task_file.parent)
+        view = op.OnlinePlotsView(task_file.parent, live=True)
         model = view.model
         assert hasattr(model, 'jsonableWatcher')
         assert Path(model.jsonableWatcher.files()[0]) == task_file
@@ -42,7 +42,7 @@ class TestOnlinePlots:
         assert view.model._n_trials > 0
 
     def test_colors(self, task_file, qtbot):
-        view = op.OnlinePlotsView(task_file.parent)
+        view = op.OnlinePlotsView(task_file.parent, live=True)
         model = view.model
         model._trial_data['response_time'] = 1
         model._seconds_elapsed = 0

--- a/iblrig/test/test_online_plots.py
+++ b/iblrig/test/test_online_plots.py
@@ -35,6 +35,10 @@ class TestOnlinePlots:
         with qtbot.waitSignal(model.jsonableWatcher.fileChanged, timeout=5), open(task_file, 'a') as f:
             f.writelines([line])
         assert model._n_trials == n_trials + 1
+        path_online_plots = task_file.parent / 'online_plots.png'
+        assert not path_online_plots.exists()
+        view.close()
+        assert path_online_plots.exists()
         model.jsonableWatcher.removePath(str(task_file))
 
     def test_from_existing_file(self, task_file, qtbot):


### PR DESCRIPTION
- `ActiveChoiceWorldSession` now uses multiprocessing.Process to run online plots
- a PNG will be stored to the session's raw data folder upon closing the online plots
- it will be moved to the session folder before registering the session and then registered as a session note