### PR TITLE
Refactor dud session handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+8.29.2
+------
+* fixed: handling of dud sessions (session folders emptied rather than deleted)
+
 8.29.1
 ------
 * fixed: jitter in Gabor stimulus of passive task

--- a/iblrig/__init__.py
+++ b/iblrig/__init__.py
@@ -6,4 +6,4 @@
 # 5) git tag the release in accordance to the version number below (after merge!)
 # >>> git tag 8.15.6
 # >>> git push origin --tags
-__version__ = '8.29.1'
+__version__ = '8.29.2'

--- a/iblrig/gui/wizard.py
+++ b/iblrig/gui/wizard.py
@@ -1212,19 +1212,28 @@ class RigWizard(QMainWindow, Ui_wizard):
 
             # check if session was a dud
             if (
-                (ntrials := session_data['NTRIALS']) < 42
+                (n_trials := session_data['NTRIALS']) < 42
                 and not any([x in self.model.task_name for x in ('spontaneous', 'passive')])
                 and not self.append_session
             ):
                 answer = QMessageBox.question(
                     self,
                     'Is this a dud?',
-                    f'The session consisted of only {ntrials:d} trial'
-                    f'{"s" if ntrials > 1 else ""} and appears to be a dud.\n\n'
+                    f'The session consisted of only {n_trials:d} trial'
+                    f'{"s" if n_trials > 1 else ""} and appears to be a dud.\n\n'
                     f'Should it be deleted?',
                 )
                 if answer == QMessageBox.Yes:
-                    shutil.rmtree(self.model.session_folder)
+                    # touch dud.flag file
+                    self.model.session_folder.joinpath('dud.flag').touch()
+
+                    # add a dud flag to the experiment description file
+
+                    # remove all subdirectories (`raw_task_data_00`, `raw_video_data`, ...) to save space
+                    for item in self.model.session_folder.iterdir():
+                        if item.is_dir():
+                            shutil.rmtree(item)
+
                     self.previous_subject = None
                     return
             self.previous_subject = self.model.subject

--- a/iblrig/gui/wizard.py
+++ b/iblrig/gui/wizard.py
@@ -1227,8 +1227,6 @@ class RigWizard(QMainWindow, Ui_wizard):
                     # touch dud.flag file
                     self.model.session_folder.joinpath('dud.flag').touch()
 
-                    # add a dud flag to the experiment description file
-
                     # remove all subdirectories (`raw_task_data_00`, `raw_video_data`, ...) to save space
                     for item in self.model.session_folder.iterdir():
                         if item.is_dir():

--- a/iblrig/transfer_experiments.py
+++ b/iblrig/transfer_experiments.py
@@ -166,6 +166,9 @@ class SessionCopier:
         Will try to get as far as possible in the copy process (from states 0 init experiment to state 3 finalize experiment)
         if possible, and return earlier if the process can't be completed.
         """
+        if self.session_path.joinpath('dud.flag').exists():
+            log.info(f'Skipping {self.session_path} because it has been marked as a dud.')
+            return
         if self.state == CopyState.HARD_RESET:  # this case is not implemented automatically and corresponds to a hard reset
             log.info(f'{self.state}, {self.session_path}')
             shutil.rmtree(self.remote_session_path)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.10.*"
 resolution-markers = [
     "sys_platform == 'darwin'",
@@ -16,6 +16,7 @@ required-markers = [
 name = "aenum"
 version = "3.1.16"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/7a/61ed58e8be9e30c3fe518899cc78c284896d246d51381bab59b5db11e1f3/aenum-3.1.16.tar.gz", hash = "sha256:bfaf9589bdb418ee3a986d85750c7318d9d2839c1b1a1d6fe8fc53ec201cf140", size = 137693, upload-time = "2026-01-12T22:34:38.819Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/52/6ad8f63ec8da1bf40f96996d25d5b650fdd38f5975f8c813732c47388f18/aenum-3.1.16-py3-none-any.whl", hash = "sha256:9035092855a98e41b66e3d0998bd7b96280e85ceb3a04cc035636138a1943eaf", size = 165627, upload-time = "2025-04-25T03:17:58.89Z" },
 ]
@@ -865,7 +866,7 @@ typing = [
 requires-dist = [
     { name = "annotated-types", specifier = ">=0.7.0" },
     { name = "graphviz", specifier = ">=0.20.3" },
-    { name = "ibl-photometry", specifier = ">=0.1.1" },
+    { name = "ibl-photometry", specifier = "==0.1.1" },
     { name = "iblatlas", specifier = ">=0.9.0" },
     { name = "ibllib", specifier = ">=3.4.0" },
     { name = "iblpybpod-no-gui", specifier = ">=3.1.1" },


### PR DESCRIPTION
### updated logic for handling dud sessions
If all of the following is True ...
1. number of trials is smaller than 42,
2. task name does not contain the strings `spontaneous` or `passive`, and
3. the session is not appended

... the user will be asked if the session is a dud an should be deleted. If they answer yes:

- a `dud.flag` will be touched, and
- all sub-folders to the session-folder will be unlinked

Note that this does _not_ change anything for appended sessions.