### PR TITLE
bugfix for neurophotometrics copier under certain timing conditions a…

### DIFF
--- a/iblrig/neurophotometrics.py
+++ b/iblrig/neurophotometrics.py
@@ -350,12 +350,11 @@ def neurophotometrics_description(
             return {'devices': {'neurophotometrics': description}}
         case 'daqami':
             hardware_settings = iblrig.path_helper.load_pydantic_yaml(HardwareSettings)
-            settings = hardware_settings.device_neurophotometrics
             experiment_description = {'devices': {'neurophotometrics': description}}
             experiment_description['devices']['neurophotometrics']['sync_metadata'] = dict(
                 acquisition_software='daqami',
                 collection='raw_photometry_data',
-                frameclock_channel=settings.FRAMECLOCK_CHANNEL,
+                frameclock_channel=hardware_settings.device_neurophotometrics['FRAMECLOCK_CHANNEL'],
             )
             return experiment_description
         case _:

--- a/iblrig/test/test_transfers.py
+++ b/iblrig/test/test_transfers.py
@@ -77,40 +77,98 @@ class TestIntegrationTransferExperimentsBase(unittest.TestCase):
     def tearDown(self):
         self.td.cleanup()
 
-    def side_effect(self, *args, filename=None, **kwargs):
+    def return_settings_from_template(self, *args, filename=None, **kwargs):
+        """side effect for mocking: return the iblrig / hardware settings
+        from the respective template file"""
         if filename.name.endswith('hardware_settings.yaml'):
             return self.hardware_settings
-        else:
+        elif filename.name.endswith('iblrig_settings.yaml'):
             return self.iblrig_settings
+        else:
+            raise FileNotFoundError(f'unknown settings file: {filename}')
 
 
 class TestIntegrationTransferExperimentsPhotometry(TestIntegrationTransferExperimentsBase):
     """for testing the photometry"""
 
-    def create_fake_data(self, start_time: datetime | None = None) -> Path:
-        if start_time is None:
-            start_time = datetime.now()
-        datestr = start_time.strftime('%Y-%m-%d')
-        timestr = start_time.strftime('T%H%M%S')
-        neurophotometrics_folder = self.iblrig_settings['iblrig_local_data_path'].joinpath('neurophotometrics', datestr, timestr)
+    neurophotometrics_hardware_defaults = {'FRAMECLOCK_CHANNEL': 1}
+
+    def return_settings_from_template(self, *args, filename=None, **kwargs):
+        """for mocking: return the iblrig / hardware settings from the respective
+        template file"""
+        if filename.name.endswith('hardware_settings.yaml'):
+            self.hardware_settings['device_neurophotometrics'] = self.neurophotometrics_hardware_defaults
+            return self.hardware_settings
+        elif filename.name.endswith('iblrig_settings.yaml'):
+            return self.iblrig_settings
+        else:
+            raise FileNotFoundError(f'unknown settings file: {filename}')
+
+    def create_fake_data(
+        self,
+        neurophotometrics_start_time: datetime | None = None,
+        sync_mode: str = 'bpod',
+        daqami_offset_timedelta: timedelta | None = None,
+    ) -> Path:
+        """creates photometry data for testing the copier, returns the path of the
+        session folder that was created"""
+        if neurophotometrics_start_time is None:
+            neurophotometrics_start_time = datetime.now()
+
+        # create neurophotometrics folder
+        neurophotometrics_folder = (
+            self.iblrig_settings['iblrig_local_data_path']
+            / 'neurophotometrics'
+            / neurophotometrics_start_time.strftime('%Y-%m-%d')
+            / neurophotometrics_start_time.strftime('T%H%M%S')
+        )
         neurophotometrics_folder.mkdir(exist_ok=True, parents=True)
 
-        # creating fake digital_inputs.csv
-        cols_dtypes = dict(
-            ChannelName=str,
-            Channel='int8',
-            AlwaysTrue='bool',
-            SystemTimestamp='float64',
-            ComputerTimestamp='float64',
-        )
-        cols = list(cols_dtypes.keys())
-        digital_inputs_df = pd.DataFrame(np.random.randn(10, len(cols)), columns=cols)
-        for col, dtype in cols_dtypes.items():
-            digital_inputs_df[col] = digital_inputs_df[col].astype(dtype)
+        if sync_mode == 'bpod':
+            # creating fake digital_inputs.csv
 
-        digital_inputs_df.to_csv(neurophotometrics_folder / 'digital_inputs.csv')
+            # NOTE
+            # ideally, we would import this definition from iblphotometry
+            # iblphotometry should not be a dependency of iblrig
+            # photometry (or any modality) specific code should live in a different module/repo
+            # that extends iblrig and can import iblphotometry
+            cols_dtypes = dict(
+                ChannelName=str,
+                Channel='int8',
+                AlwaysTrue='bool',
+                SystemTimestamp='float64',
+                ComputerTimestamp='float64',
+            )
+            cols = list(cols_dtypes.keys())
+            # create the digital inputs file
+            digital_inputs_df = pd.DataFrame(np.random.randn(10, len(cols)), columns=cols)
+            for col, dtype in cols_dtypes.items():
+                digital_inputs_df[col] = digital_inputs_df[col].astype(dtype)
+            digital_inputs_df.to_csv(neurophotometrics_folder / 'digital_inputs.csv')
+
+        elif sync_mode == 'daqami':
+            # creating daqami sync data created with a time offset
+            if daqami_offset_timedelta is None:
+                # by default, daqami is assumed to have started 5 minutes before the neurophotometrics
+                daqami_offset_timedelta = timedelta(min=-5)
+            daqami_start_time = neurophotometrics_start_time + daqami_offset_timedelta
+
+            # creating fake daq sync file
+            daqami_folder = (
+                self.iblrig_settings['iblrig_local_data_path']
+                / 'daqami'
+                / daqami_start_time.strftime('%Y-%m-%d')
+                / daqami_start_time.strftime('T%H%M')
+            )
+            daqami_folder.mkdir(parents=True, exist_ok=True)
+            # in order to later test if the correct daq files were copied, the timestamp of their creation
+            # is written into the file (as it is stripped from the filename that ispresent at the local
+            # but not at the remote)
+            with open(daqami_folder / 'daqami_sync.tdms', 'w') as file_handle:
+                file_handle.write(daqami_start_time.isoformat())
 
         # creating fake photometry data file
+        # see note above
         cols_dtypes = dict(
             FrameCounter='int64',
             SystemTimestamp='float64',
@@ -129,20 +187,25 @@ class TestIntegrationTransferExperimentsPhotometry(TestIntegrationTransferExperi
         logger.info('Created fake photometry data in %s', neurophotometrics_folder)
         return neurophotometrics_folder
 
-    def test_copier(self):
+    def test_copier_bpod(self):
+        # DEBUG to check: timestamp of created session
         session = _create_behavior_session(ntrials=50, kwargs=self.session_kwargs)
-        timestamp_session = datetime.fromisoformat(session.session_info['SESSION_START_TIME'])
+        session_start_time = datetime.fromisoformat(session.session_info['SESSION_START_TIME'])
 
         # create several fake photometry datasets
         # this is to assure that the correct dataset is picked by the copier
-        timestamp_neurophotometrics = timestamp_session + timedelta(minutes=-5)
-        self.create_fake_data(timestamp_neurophotometrics + timedelta(minutes=-20))
-        self.create_fake_data(timestamp_neurophotometrics + timedelta(minutes=-10))
-        local_photometry_path = self.create_fake_data(timestamp_neurophotometrics)  # this is the relevant one
-        self.create_fake_data(timestamp_neurophotometrics + timedelta(minutes=10))
+        neurophotometrics_start_time_a = session_start_time + timedelta(hours=-1)
+        neurophotometrics_start_time_b = session_start_time + timedelta(minutes=-5)
+        neurophotometrics_start_time_c = session_start_time + timedelta(hours=+2)
+
+        _ = self.create_fake_data(neurophotometrics_start_time=neurophotometrics_start_time_a)
+        local_photometry_folder_b = self.create_fake_data(
+            neurophotometrics_start_time=neurophotometrics_start_time_b
+        )  # < this is the relevant one
+        _ = self.create_fake_data(neurophotometrics_start_time=neurophotometrics_start_time_c)
 
         # copy data
-        with mock.patch('iblrig.path_helper._load_settings_yaml', side_effect=self.side_effect):
+        with mock.patch('iblrig.path_helper._load_settings_yaml', side_effect=self.return_settings_from_template):
             iblrig.neurophotometrics.init_neurophotometrics_subject(
                 subject='test_subject',
                 rois=['Region1G', 'Region2G'],
@@ -153,22 +216,96 @@ class TestIntegrationTransferExperimentsPhotometry(TestIntegrationTransferExperi
             (copier,) = iblrig.commands.transfer_data(tag='neurophotometrics')
             self.assertEqual(copier.state, CopyState.COMPLETE)
 
-        # check that the correct data was copied
-        remote_photometry_path = copier.remote_session_path.joinpath('raw_photometry_data')
-        assert remote_photometry_path.joinpath('_neurophotometrics_fpData.channels.csv').exists()
-        assert remote_photometry_path.joinpath('_neurophotometrics_fpData.digitalInputs.pqt').exists()
-        assert remote_photometry_path.joinpath('_neurophotometrics_fpData.raw.pqt').exists()
-        # check raw data
-        data_raw_local = pd.read_csv(local_photometry_path.joinpath('raw_photometry', 'raw_photometry.csv'))
-        data_raw_remote = pd.read_parquet(remote_photometry_path.joinpath('_neurophotometrics_fpData.raw.pqt'))
+        # test if the files were copied
+        assert (copier.remote_session_path / 'raw_photometry_data' / '_neurophotometrics_fpData.channels.csv').exists()
+        assert (copier.remote_session_path / 'raw_photometry_data' / '_neurophotometrics_fpData.digitalInputs.pqt').exists()
+        assert (copier.remote_session_path / 'raw_photometry_data' / '_neurophotometrics_fpData.raw.pqt').exists()
+
+        # verify the contents of the raw photometry files
+        data_raw_local = pd.read_csv(local_photometry_folder_b / 'raw_photometry' / 'raw_photometry.csv')
+        data_raw_remote = pd.read_parquet(
+            copier.remote_session_path / 'raw_photometry_data' / '_neurophotometrics_fpData.raw.pqt'
+        )
         pd.testing.assert_frame_equal(data_raw_local, data_raw_remote, check_dtype=False)
-        # check digital inputs data
-        assert remote_photometry_path.joinpath('_neurophotometrics_fpData.digitalInputs.pqt').exists()
-        data_digital_inputs_local = pd.read_csv(local_photometry_path.joinpath('digital_inputs.csv'))
+
+        # verify the contents of the digital input files
+        assert (copier.remote_session_path / 'raw_photometry_data' / '_neurophotometrics_fpData.digitalInputs.pqt').exists()
+        data_digital_inputs_local = pd.read_csv(local_photometry_folder_b / 'digital_inputs.csv')
         data_digital_inputs_remote = pd.read_parquet(
-            remote_photometry_path.joinpath('_neurophotometrics_fpData.digitalInputs.pqt')
+            copier.remote_session_path / 'raw_photometry_data' / '_neurophotometrics_fpData.digitalInputs.pqt'
         )
         pd.testing.assert_frame_equal(data_digital_inputs_local, data_digital_inputs_remote, check_dtype=False)
+
+    def test_copier_daq(self):
+        session = _create_behavior_session(ntrials=50, kwargs=self.session_kwargs)
+        session_start_time = datetime.fromisoformat(session.session_info['SESSION_START_TIME'])
+
+        # create several fake photometry datasets
+        # this is to assure that the correct dataset is picked by the copier
+        neurophotometrics_start_time_a = session_start_time + timedelta(hours=-1)
+        neurophotometrics_start_time_b = session_start_time + timedelta(minutes=-5)
+        neurophotometrics_start_time_c = session_start_time + timedelta(hours=+1)
+
+        daqami_offset_a = timedelta(hours=-2)  # 2h before the first neurophotometrics
+        daqami_offset_b = timedelta(minutes=-10)  # 10 minutes before the session of interest
+        daqami_offset_c = timedelta(minutes=-30)  # 30 minutes before the last neurophotometrics session
+
+        daqami_start_time_a = neurophotometrics_start_time_a + daqami_offset_a
+        daqami_start_time_b = neurophotometrics_start_time_b + daqami_offset_b
+        daqami_start_time_c = neurophotometrics_start_time_c + daqami_offset_c
+
+        _ = self.create_fake_data(
+            neurophotometrics_start_time=neurophotometrics_start_time_a,
+            daqami_offset_timedelta=daqami_offset_a,
+            sync_mode='daqami',
+        )
+        local_photometry_folder_b = self.create_fake_data(
+            neurophotometrics_start_time=neurophotometrics_start_time_b,
+            daqami_offset_timedelta=daqami_offset_b,
+            sync_mode='daqami',
+        )  # < this is the relevant one
+        _ = self.create_fake_data(
+            neurophotometrics_start_time=neurophotometrics_start_time_c,
+            daqami_offset_timedelta=daqami_offset_c,
+            sync_mode='daqami',
+        )
+
+        # copy data
+        with mock.patch('iblrig.path_helper._load_settings_yaml', side_effect=self.return_settings_from_template):
+            iblrig.neurophotometrics.init_neurophotometrics_subject(
+                subject='test_subject',
+                rois=['Region1G', 'Region2G'],
+                locations=['VTA', 'SNc'],
+                sync_channel=0,
+                sync_mode='daqami',
+            )
+            (copier,) = iblrig.commands.transfer_data(tag='neurophotometrics')
+            self.assertEqual(copier.state, CopyState.COMPLETE)
+
+        # check that the correct data was copied
+        assert (copier.remote_session_path / 'raw_photometry_data' / '_neurophotometrics_fpData.raw.pqt').exists()
+        # check raw data
+        data_raw_local = pd.read_csv(local_photometry_folder_b / 'raw_photometry' / 'raw_photometry.csv')
+        data_raw_remote = pd.read_parquet(
+            copier.remote_session_path / 'raw_photometry_data' / '_neurophotometrics_fpData.raw.pqt'
+        )
+        pd.testing.assert_frame_equal(data_raw_local, data_raw_remote, check_dtype=False)
+
+        # check daq data
+        local_daqami_folder = self.iblrig_settings['iblrig_local_data_path'] / 'daqami'
+        local_daqami_file = (
+            local_daqami_folder
+            / daqami_start_time_b.strftime('%Y-%m-%d')
+            / daqami_start_time_b.strftime('T%H%M')
+            / 'daqami_sync.tdms'
+        )
+        remote_daqami_file = copier.remote_session_path / 'raw_photometry_data' / '_mcc_DAQdata.raw.tdms'
+        with open(local_daqami_file, 'r') as file_handle:
+            daqami_timestamp_local = file_handle.readlines()
+        with open(remote_daqami_file, 'r') as file_handle:
+            daqami_timestamp_remote = file_handle.readlines()
+
+        assert daqami_timestamp_local == daqami_timestamp_remote
 
 
 class TestIntegrationTransferExperiments(TestIntegrationTransferExperimentsBase):
@@ -184,7 +321,7 @@ class TestIntegrationTransferExperiments(TestIntegrationTransferExperimentsBase)
         for hard_crash in [False, True]:
             session = _create_behavior_session(ntrials=50, hard_crash=hard_crash, kwargs=self.session_kwargs)
             session.paths.SESSION_FOLDER.joinpath('transfer_me.flag').touch()
-            with mock.patch('iblrig.path_helper._load_settings_yaml', side_effect=self.side_effect):
+            with mock.patch('iblrig.path_helper._load_settings_yaml', side_effect=self.return_settings_from_template):
                 iblrig.commands.transfer_data(
                     local_path=session.iblrig_settings['iblrig_local_data_path'],
                     remote_path=session.iblrig_settings['iblrig_remote_data_path'],
@@ -198,7 +335,7 @@ class TestIntegrationTransferExperiments(TestIntegrationTransferExperimentsBase)
         session = _create_behavior_session(ntrials=50, hard_crash=hard_crash, kwargs=self.session_kwargs)
         session.paths.SESSION_FOLDER.joinpath('transfer_me.flag').touch()
 
-        with mock.patch('iblrig.path_helper._load_settings_yaml', side_effect=self.side_effect):
+        with mock.patch('iblrig.path_helper._load_settings_yaml', side_effect=self.return_settings_from_template):
             iblrig.commands.transfer_data(tag='behavior')
         sc = BehaviorCopier(session_path=session.paths.SESSION_FOLDER, remote_subjects_folder=session.paths.REMOTE_SUBJECT_FOLDER)
         self.assertEqual(sc.state, 3)

--- a/iblrig/test/test_transfers.py
+++ b/iblrig/test/test_transfers.py
@@ -109,6 +109,7 @@ class TestIntegrationTransferExperimentsPhotometry(TestIntegrationTransferExperi
         neurophotometrics_start_time: datetime | None = None,
         sync_mode: str = 'bpod',
         daqami_offset_timedelta: timedelta | None = None,
+        create_daqami_data: bool = True,
     ) -> Path:
         """creates photometry data for testing the copier, returns the path of the
         session folder that was created"""
@@ -146,8 +147,10 @@ class TestIntegrationTransferExperimentsPhotometry(TestIntegrationTransferExperi
                 digital_inputs_df[col] = digital_inputs_df[col].astype(dtype)
             digital_inputs_df.to_csv(neurophotometrics_folder / 'digital_inputs.csv')
 
-        elif sync_mode == 'daqami':
+        elif sync_mode == 'daqami' and create_daqami_data:
             # creating daqami sync data created with a time offset
+            # only conditionally creating daqami data because it's possible to have
+            # only one file per day
             if daqami_offset_timedelta is None:
                 # by default, daqami is assumed to have started 5 minutes before the neurophotometrics
                 daqami_offset_timedelta = timedelta(min=-5)
@@ -297,6 +300,79 @@ class TestIntegrationTransferExperimentsPhotometry(TestIntegrationTransferExperi
             local_daqami_folder
             / daqami_start_time_b.strftime('%Y-%m-%d')
             / daqami_start_time_b.strftime('T%H%M')
+            / 'daqami_sync.tdms'
+        )
+        remote_daqami_file = copier.remote_session_path / 'raw_photometry_data' / '_mcc_DAQdata.raw.tdms'
+        with open(local_daqami_file) as file_handle:
+            daqami_timestamp_local = file_handle.readlines()
+        with open(remote_daqami_file) as file_handle:
+            daqami_timestamp_remote = file_handle.readlines()
+
+        assert daqami_timestamp_local == daqami_timestamp_remote
+
+    def test_copier_daq_single_daq_file(self):
+        """this test case covers the scenario in which there is only one file one the DAQ,
+        and it's time stamp is _after_ the neurophotometrics timestamp
+        I think this is caused by the user opening bonsai before the daqami software and the
+        timestamp is written at the moment of bonsai opening, _not_ when the play button is
+        pushed"""
+        session = _create_behavior_session(ntrials=50, kwargs=self.session_kwargs)
+        session_start_time = datetime.fromisoformat(session.session_info['SESSION_START_TIME'])
+
+        # create several fake photometry datasets
+        # this is to assure that the correct dataset is picked by the copier
+        neurophotometrics_start_time_a = session_start_time + timedelta(minutes=-30)
+        neurophotometrics_start_time_b = session_start_time + timedelta(hours=+2)
+        neurophotometrics_start_time_c = session_start_time + timedelta(hours=+3)
+
+        daqami_offset = timedelta(minutes=5)  # daq timestamp is just after neurophotometrics timestamp
+
+        daqami_start_time = neurophotometrics_start_time_a + daqami_offset
+
+        local_photometry_folder_a = self.create_fake_data(
+            neurophotometrics_start_time=neurophotometrics_start_time_a,
+            daqami_offset_timedelta=daqami_offset,
+            sync_mode='daqami',
+            create_daqami_data=True,
+        )  # < this is the relevant one for this test
+        _ = self.create_fake_data(
+            neurophotometrics_start_time=neurophotometrics_start_time_b,
+            sync_mode='daqami',
+            create_daqami_data=False,
+        )
+        _ = self.create_fake_data(
+            neurophotometrics_start_time=neurophotometrics_start_time_c,
+            sync_mode='daqami',
+            create_daqami_data=False,
+        )
+
+        # copy data
+        with mock.patch('iblrig.path_helper._load_settings_yaml', side_effect=self.return_settings_from_template):
+            iblrig.neurophotometrics.init_neurophotometrics_subject(
+                subject='test_subject',
+                rois=['Region1G', 'Region2G'],
+                locations=['VTA', 'SNc'],
+                sync_channel=0,
+                sync_mode='daqami',
+            )
+            (copier,) = iblrig.commands.transfer_data(tag='neurophotometrics')
+            self.assertEqual(copier.state, CopyState.COMPLETE)
+
+        # check that the correct data was copied
+        assert (copier.remote_session_path / 'raw_photometry_data' / '_neurophotometrics_fpData.raw.pqt').exists()
+        # check raw data
+        data_raw_local = pd.read_csv(local_photometry_folder_a / 'raw_photometry' / 'raw_photometry.csv')
+        data_raw_remote = pd.read_parquet(
+            copier.remote_session_path / 'raw_photometry_data' / '_neurophotometrics_fpData.raw.pqt'
+        )
+        pd.testing.assert_frame_equal(data_raw_local, data_raw_remote, check_dtype=False)
+
+        # check daq data
+        local_daqami_folder = self.iblrig_settings['iblrig_local_data_path'] / 'daqami'
+        local_daqami_file = (
+            local_daqami_folder
+            / daqami_start_time.strftime('%Y-%m-%d')
+            / daqami_start_time.strftime('T%H%M')
             / 'daqami_sync.tdms'
         )
         remote_daqami_file = copier.remote_session_path / 'raw_photometry_data' / '_mcc_DAQdata.raw.tdms'

--- a/iblrig/test/test_transfers.py
+++ b/iblrig/test/test_transfers.py
@@ -250,9 +250,9 @@ class TestIntegrationTransferExperimentsPhotometry(TestIntegrationTransferExperi
         daqami_offset_b = timedelta(minutes=-10)  # 10 minutes before the session of interest
         daqami_offset_c = timedelta(minutes=-30)  # 30 minutes before the last neurophotometrics session
 
-        daqami_start_time_a = neurophotometrics_start_time_a + daqami_offset_a
+        _ = neurophotometrics_start_time_a + daqami_offset_a
         daqami_start_time_b = neurophotometrics_start_time_b + daqami_offset_b
-        daqami_start_time_c = neurophotometrics_start_time_c + daqami_offset_c
+        _ = neurophotometrics_start_time_c + daqami_offset_c
 
         _ = self.create_fake_data(
             neurophotometrics_start_time=neurophotometrics_start_time_a,
@@ -300,9 +300,9 @@ class TestIntegrationTransferExperimentsPhotometry(TestIntegrationTransferExperi
             / 'daqami_sync.tdms'
         )
         remote_daqami_file = copier.remote_session_path / 'raw_photometry_data' / '_mcc_DAQdata.raw.tdms'
-        with open(local_daqami_file, 'r') as file_handle:
+        with open(local_daqami_file) as file_handle:
             daqami_timestamp_local = file_handle.readlines()
-        with open(remote_daqami_file, 'r') as file_handle:
+        with open(remote_daqami_file) as file_handle:
             daqami_timestamp_remote = file_handle.readlines()
 
         assert daqami_timestamp_local == daqami_timestamp_remote

--- a/iblrig/transfer_experiments.py
+++ b/iblrig/transfer_experiments.py
@@ -656,10 +656,11 @@ class NeurophotometricsCopier(SessionCopier):
                 # get the corresponding daqami folder: find the corresponding daqami folder by the smallest positive timedelta
                 timedeltas = [neurophotometrics_start_time - start_time for start_time in daqami_start_times]
 
-                # note: the timestamp of the neurophotometric is written when the Bonsai workflow is opened, NOT when the
-                # bonsai workflow is started! Therefore the neurophotometrics file is still timestamped BEFORE the
-                # daqami file, even though the bonsai recording starts after ...
-                dt_min = min([dt for dt in timedeltas if dt < timedelta(0)])
+                # also adding here the grace timedelta of 1 minute because of comparing HHMM to HHMMSS timestamps
+                timedeltas = [t + timedelta(0, 60) for t in timedeltas]
+                dt_min = min([dt for dt in timedeltas if dt > timedelta(0)])
+                if dt_min < timedelta(0,600):
+                    log.warning('time difference between daqami and neurophotometrics start times is more than 5 minutes')
                 daqami_folder = folders[timedeltas.index(dt_min)]
 
                 # check here if multiple daqami files exist
@@ -679,11 +680,19 @@ class NeurophotometricsCopier(SessionCopier):
                 # copy to the remote folder
                 remote_sync_path = self.remote_session_path.joinpath(neurophotometrics_description['sync_metadata']['collection'])
                 remote_sync_path.mkdir(exist_ok=True, parents=True)
+                remote_file = remote_sync_path.joinpath('_mcc_DAQdata.raw.tdms')
+                if remote_file.exists():  # prevent overwriting already copied files
+                    today = datetime.now().strftime("%Y-%m-%d")
+                    shutil.copy(remote_file, remote_file.with_suffix(f'.{today}.backup'))
                 shutil.copy(daqami_file, remote_sync_path.joinpath('_mcc_DAQdata.raw.tdms'))
 
         # read neurophotometrics file
         raw_photometry_df = pd.read_csv(csv_raw_photometry)
-        raw_photometry_df.to_parquet(remote_photometry_path.joinpath('_neurophotometrics_fpData.raw.pqt'))
+        remote_file = remote_photometry_path.joinpath('_neurophotometrics_fpData.raw.pqt')
+        if remote_file.exists(): # prevent overwriting already copied files
+            today = datetime.now().strftime("%Y-%m-%d")
+            shutil.copy(remote_file, remote_file.with_suffix(f'.{today}.backup'))
+        raw_photometry_df.to_parquet(remote_file)
 
         # TODO why are we explicitly copying this file?
         shutil.copy(

--- a/iblrig/transfer_experiments.py
+++ b/iblrig/transfer_experiments.py
@@ -659,7 +659,7 @@ class NeurophotometricsCopier(SessionCopier):
                 # also adding here the grace timedelta of 1 minute because of comparing HHMM to HHMMSS timestamps
                 timedeltas = [t + timedelta(0, 60) for t in timedeltas]
                 dt_min = min([dt for dt in timedeltas if dt > timedelta(0)])
-                if dt_min < timedelta(0,600):
+                if dt_min < timedelta(0, 600):
                     log.warning('time difference between daqami and neurophotometrics start times is more than 5 minutes')
                 daqami_folder = folders[timedeltas.index(dt_min)]
 
@@ -682,15 +682,15 @@ class NeurophotometricsCopier(SessionCopier):
                 remote_sync_path.mkdir(exist_ok=True, parents=True)
                 remote_file = remote_sync_path.joinpath('_mcc_DAQdata.raw.tdms')
                 if remote_file.exists():  # prevent overwriting already copied files
-                    today = datetime.now().strftime("%Y-%m-%d")
+                    today = datetime.now().strftime('%Y-%m-%d')
                     shutil.copy(remote_file, remote_file.with_suffix(f'.{today}.backup'))
                 shutil.copy(daqami_file, remote_sync_path.joinpath('_mcc_DAQdata.raw.tdms'))
 
         # read neurophotometrics file
         raw_photometry_df = pd.read_csv(csv_raw_photometry)
         remote_file = remote_photometry_path.joinpath('_neurophotometrics_fpData.raw.pqt')
-        if remote_file.exists(): # prevent overwriting already copied files
-            today = datetime.now().strftime("%Y-%m-%d")
+        if remote_file.exists():  # prevent overwriting already copied files
+            today = datetime.now().strftime('%Y-%m-%d')
             shutil.copy(remote_file, remote_file.with_suffix(f'.{today}.backup'))
         raw_photometry_df.to_parquet(remote_file)
 

--- a/iblrig/transfer_experiments.py
+++ b/iblrig/transfer_experiments.py
@@ -653,15 +653,25 @@ class NeurophotometricsCopier(SessionCopier):
                     '/'.join(neurophotometrics_session_path.parts[-2:]), '%Y-%m-%d/T%H%M%S'
                 )
 
-                # get the corresponding daqami folder: find the corresponding daqami folder by the smallest positive timedelta
-                timedeltas = [neurophotometrics_start_time - start_time for start_time in daqami_start_times]
+                if len(daqami_start_times) == 1:
+                    # in this case, there is a single daq file for the entire day
+                    # and it might be, that this daq file starts _slightly_ after the
+                    # bonsai timestamp (because of the order of initialization discrepancy)
+                    daqami_folder = folders[0]
+                    if abs(neurophotometrics_start_time - daqami_start_times[0]) > timedelta(minutes=20):
+                        raise ValueError(
+                            'daq start time is more then 20 minutes after the neurophotometrics start time, manually inspect'
+                        )
+                else:
+                    # get the corresponding daqami folder: find the corresponding daqami folder by the smallest positive timedelta
+                    timedeltas = [neurophotometrics_start_time - start_time for start_time in daqami_start_times]
 
-                # also adding here the grace timedelta of 1 minute because of comparing HHMM to HHMMSS timestamps
-                timedeltas = [t + timedelta(0, 60) for t in timedeltas]
-                dt_min = min([dt for dt in timedeltas if dt > timedelta(0)])
-                if dt_min > timedelta(minutes=30):
-                    log.warning('time difference between daqami and neurophotometrics start times is more than 30 minutes')
-                daqami_folder = folders[timedeltas.index(dt_min)]
+                    # also adding here the grace timedelta of 1 minute because of comparing HHMM to HHMMSS timestamps
+                    timedeltas = [t + timedelta(0, 60) for t in timedeltas]
+                    dt_min = min([dt for dt in timedeltas if dt > timedelta(0)])
+                    if dt_min > timedelta(minutes=30):
+                        log.warning('time difference between daqami and neurophotometrics start times is more than 30 minutes')
+                    daqami_folder = folders[timedeltas.index(dt_min)]
 
                 # check here if multiple daqami files exist
                 if len(list(daqami_folder.glob('*.tdms'))) == 1:

--- a/iblrig/transfer_experiments.py
+++ b/iblrig/transfer_experiments.py
@@ -644,7 +644,7 @@ class NeurophotometricsCopier(SessionCopier):
                 # find the daqami files that correspond to the current acquisition
                 session_date = subject_ini_time.date().strftime('%Y-%m-%d')
                 # all folders of that day, parse by start with T
-                folders = local_and_remote_paths['local_data_folder'].joinpath('daqami', session_date).glob('*/')
+                folders = (local_and_remote_paths['local_data_folder'] / 'daqami' / session_date).glob('*/')
                 folders = [folder for folder in folders if folder.name.startswith('T')]
                 daqami_start_times = [datetime.strptime('/'.join(folder.parts[-2:]), '%Y-%m-%d/T%H%M') for folder in folders]
 
@@ -659,12 +659,12 @@ class NeurophotometricsCopier(SessionCopier):
                 # also adding here the grace timedelta of 1 minute because of comparing HHMM to HHMMSS timestamps
                 timedeltas = [t + timedelta(0, 60) for t in timedeltas]
                 dt_min = min([dt for dt in timedeltas if dt > timedelta(0)])
-                if dt_min < timedelta(0, 600):
-                    log.warning('time difference between daqami and neurophotometrics start times is more than 5 minutes')
+                if dt_min > timedelta(minutes=30):
+                    log.warning('time difference between daqami and neurophotometrics start times is more than 30 minutes')
                 daqami_folder = folders[timedeltas.index(dt_min)]
 
                 # check here if multiple daqami files exist
-                if len(list(daqami_folder.glob('*'))) == 2:
+                if len(list(daqami_folder.glob('*.tdms'))) == 1:
                     # this is the expected case, all is fine
                     daqami_file = daqami_folder.joinpath('daqami_sync.tdms')
                 else:
@@ -681,9 +681,9 @@ class NeurophotometricsCopier(SessionCopier):
                 remote_sync_path = self.remote_session_path.joinpath(neurophotometrics_description['sync_metadata']['collection'])
                 remote_sync_path.mkdir(exist_ok=True, parents=True)
                 remote_file = remote_sync_path.joinpath('_mcc_DAQdata.raw.tdms')
-                if remote_file.exists():  # prevent overwriting already copied files
-                    today = datetime.now().strftime('%Y-%m-%d')
-                    shutil.copy(remote_file, remote_file.with_suffix(f'.{today}.backup'))
+                # if remote_file.exists():  # prevent overwriting already copied files
+                #     today = datetime.now().strftime('%Y-%m-%d')
+                #     shutil.copy(remote_file, remote_file.with_suffix(f'.{today}.backup'))
                 shutil.copy(daqami_file, remote_sync_path.joinpath('_mcc_DAQdata.raw.tdms'))
 
         # read neurophotometrics file


### PR DESCRIPTION
…ssociating the wrong daqami file to the neurophotometrics file.

Additionally, when the copier is re-run, it backups previously copied files (and does not overwrite them)