### PR TITLE
Add SCREEN_RESOLUTION setting for non-standard screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 8.29.2
 ------
 * changed: allow free-form subject when Alyx URL is not set
+* fixed: new SCREEN_RESOLUTION setting for non-standard screens (fixes screen detection during Frame2TTL calibration)
 
 8.29.1
 ------

--- a/iblrig/gui/frame2ttl.py
+++ b/iblrig/gui/frame2ttl.py
@@ -38,7 +38,11 @@ class Frame2TTLCalibrationDialog(QtWidgets.QDialog, Ui_frame2ttl):
 
         # start calibration of light value (use timer to allow for drawing of target)
         self.uiLabelLightValue.setText('calibrating ...')
-        self.target = Frame2TTLCalibrationTarget(self, color=QtGui.QColorConstants.White)
+        self.target = Frame2TTLCalibrationTarget(
+            self,
+            color=QtGui.QColorConstants.White,
+            screen_resolution=hardware_settings.device_screen.SCREEN_RESOLUTION,
+        )
         QTimer.singleShot(self._waitForScreen, self._calibrateLight)
 
     def _calibrateLight(self):
@@ -75,6 +79,7 @@ class Frame2TTLCalibrationTarget(QtWidgets.QDialog):
         parent: QWidget | None = None,
         color: QtGui.QColor = QtGui.QColorConstants.White,
         screen_index: int | None = None,
+        screen_resolution: tuple[int, int] = (2048, 1536),
         width: int | None = None,
         height: int | None = None,
         rel_pos_x: float = 1.33,
@@ -87,14 +92,14 @@ class Frame2TTLCalibrationTarget(QtWidgets.QDialog):
         if screen_index is None:
             for idx, screen in enumerate(QtWidgets.QApplication.screens()):
                 screen_index = idx
-                if screen.size().width() == 2048 and screen.size().height() == 1536:
+                if screen.size().width() == screen_resolution[0] and screen.size().height() == screen_resolution[1]:
                     break
             else:  # if no break statement occurred, i.e. no iPad screen was found
                 screen_index = 0
                 screen = QtWidgets.QApplication.screens()[0]
                 log.warning(
-                    f'Could not identify iPad screen (2048x1536) - defaulting to Screen {screen_index} '
-                    f'({screen.geometry().width()}x{screen.geometry().height()}).'
+                    f'Could not identify screen ({screen_resolution[0]}x{screen_resolution[1]}) - '
+                    f'defaulting to Screen {screen_index} ({screen.geometry().width()}x{screen.geometry().height()}).'
                 )
 
         # convert relative parameters (used in bonsai scripts) to width and height

--- a/iblrig/hardware_validation.py
+++ b/iblrig/hardware_validation.py
@@ -628,7 +628,10 @@ class ValidatorFrame2TTL(ValidatorSerial):
             app = QApplication([])
 
         # show calibration target
-        calibration_target = Frame2TTLCalibrationTarget(color=QColorConstants.Black)
+        calibration_target = Frame2TTLCalibrationTarget(
+            color=QColorConstants.Black,
+            screen_resolution=self.hardware_settings.device_screen.SCREEN_RESOLUTION,
+        )
         sleep(0.1)  # allow for screen to update
 
         # Define state-machine

--- a/iblrig/path_helper.py
+++ b/iblrig/path_helper.py
@@ -267,7 +267,7 @@ def save_pydantic_yaml(data: T, filename: Path | str | None = None) -> None:
             raise TypeError(f'Cannot deduce filename for model `{type(data).__name__}`.')
     else:
         filename = Path(filename)
-    yaml_data = data.model_dump()
+    yaml_data = data.model_dump(mode='json')
     data.model_validate(yaml_data)
     with open(filename, 'w') as f:
         log.debug(f'Dumping {type(data).__name__} to {filename.name}')

--- a/iblrig/pydantic_definitions.py
+++ b/iblrig/pydantic_definitions.py
@@ -12,7 +12,6 @@ from pydantic import (
     DirectoryPath,
     Field,
     FilePath,
-    NonNegativeInt,
     PlainSerializer,
     PositiveFloat,
     PositiveInt,
@@ -114,7 +113,7 @@ class HardwareSettingsRotaryEncoder(BunchModel):
 
 class HardwareSettingsScreen(BunchModel):
     DISPLAY_IDX: int = Field(ge=0, le=1)  # -1 = Default, 0 = First, 1 = Second, 2 = Third, etc
-    SCREEN_RESOLUTION: tuple[NonNegativeInt, NonNegativeInt] = Field(min_length=2, max_length=2, default=(2048, 1536))
+    SCREEN_RESOLUTION: tuple[PositiveInt, PositiveInt] = Field(min_length=2, max_length=2, default=(2048, 1536))
     SCREEN_FREQ_TARGET: int = Field(gt=0)
     SCREEN_FREQ_TEST_DATE: date | None = None
     SCREEN_FREQ_TEST_STATUS: str | None = None

--- a/iblrig/pydantic_definitions.py
+++ b/iblrig/pydantic_definitions.py
@@ -113,6 +113,7 @@ class HardwareSettingsRotaryEncoder(BunchModel):
 
 class HardwareSettingsScreen(BunchModel):
     DISPLAY_IDX: int = Field(ge=0, le=1)  # -1 = Default, 0 = First, 1 = Second, 2 = Third, etc
+    SCREEN_RESOLUTION: tuple[int, int] = Field(ge=0, le=2, default=(2048, 1536))
     SCREEN_FREQ_TARGET: int = Field(gt=0)
     SCREEN_FREQ_TEST_DATE: date | None = None
     SCREEN_FREQ_TEST_STATUS: str | None = None

--- a/iblrig/pydantic_definitions.py
+++ b/iblrig/pydantic_definitions.py
@@ -113,8 +113,8 @@ class HardwareSettingsRotaryEncoder(BunchModel):
 
 class HardwareSettingsScreen(BunchModel):
     DISPLAY_IDX: int = Field(ge=0, le=1)  # -1 = Default, 0 = First, 1 = Second, 2 = Third, etc
-    SCREEN_RESOLUTION: tuple[PositiveInt, PositiveInt] = Field(min_length=2, max_length=2, default=(2048, 1536))
-    SCREEN_FREQ_TARGET: int = Field(gt=0)
+    SCREEN_RESOLUTION: tuple[PositiveInt, PositiveInt] = (2048, 1536)
+    SCREEN_FREQ_TARGET: PositiveInt
     SCREEN_FREQ_TEST_DATE: date | None = None
     SCREEN_FREQ_TEST_STATUS: str | None = None
     SCREEN_LUX_DATE: date | None = None

--- a/iblrig/pydantic_definitions.py
+++ b/iblrig/pydantic_definitions.py
@@ -12,6 +12,7 @@ from pydantic import (
     DirectoryPath,
     Field,
     FilePath,
+    NonNegativeInt,
     PlainSerializer,
     PositiveFloat,
     PositiveInt,
@@ -113,7 +114,7 @@ class HardwareSettingsRotaryEncoder(BunchModel):
 
 class HardwareSettingsScreen(BunchModel):
     DISPLAY_IDX: int = Field(ge=0, le=1)  # -1 = Default, 0 = First, 1 = Second, 2 = Third, etc
-    SCREEN_RESOLUTION: tuple[int, int] = Field(ge=0, le=2, default=(2048, 1536))
+    SCREEN_RESOLUTION: tuple[NonNegativeInt, NonNegativeInt] = Field(min_length=2, max_length=2, default=(2048, 1536))
     SCREEN_FREQ_TARGET: int = Field(gt=0)
     SCREEN_FREQ_TEST_DATE: date | None = None
     SCREEN_FREQ_TEST_STATUS: str | None = None

--- a/iblrig/test/test_misc.py
+++ b/iblrig/test/test_misc.py
@@ -84,7 +84,8 @@ class TestPortSettings(unittest.TestCase):
         self.assertDictEqual(hw_settings['device_valve'], expected)
         self.assertEqual(hw_settings['RIG_NAME'], self.v7_settings['NAME'])
         expected = {k: v for k, v in self.v7_settings.items() if k.startswith('SCREEN') or k == 'DISPLAY_IDX'}
-        self.assertDictEqual(hw_settings['device_screen'], expected)
+        actual = {k:v for k, v in hw_settings['device_screen'].items() if k in expected}
+        self.assertDictEqual(actual, expected)
 
         settings_path = self.v8 / 'iblrig_settings.yaml'
         self.assertTrue(settings_path.exists())

--- a/iblrig/test/test_misc.py
+++ b/iblrig/test/test_misc.py
@@ -84,7 +84,7 @@ class TestPortSettings(unittest.TestCase):
         self.assertDictEqual(hw_settings['device_valve'], expected)
         self.assertEqual(hw_settings['RIG_NAME'], self.v7_settings['NAME'])
         expected = {k: v for k, v in self.v7_settings.items() if k.startswith('SCREEN') or k == 'DISPLAY_IDX'}
-        actual = {k:v for k, v in hw_settings['device_screen'].items() if k in expected}
+        actual = {k: v for k, v in hw_settings['device_screen'].items() if k in expected}
         self.assertDictEqual(actual, expected)
 
         settings_path = self.v8 / 'iblrig_settings.yaml'

--- a/settings/hardware_settings_template.yaml
+++ b/settings/hardware_settings_template.yaml
@@ -17,6 +17,7 @@ device_rotary_encoder:
   COM_ROTARY_ENCODER: null
 device_screen:
   DISPLAY_IDX: 1
+  SCREEN_RESOLUTION: [2048, 1536]
   SCREEN_FREQ_TARGET: 60
   SCREEN_FREQ_TEST_DATE: null  # optional
   SCREEN_FREQ_TEST_STATUS: null  # optional


### PR DESCRIPTION
Fixes screen detection during Frame2TTL calibration by allowing configuration of expected screen resolution instead of hardcoding iPad dimensions (2048x1536).